### PR TITLE
Add logic to generate an enclave quote

### DIFF
--- a/untrusted/Cargo.lock
+++ b/untrusted/Cargo.lock
@@ -191,6 +191,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-dcap"
+version = "0.1.0"
+dependencies = [
+ "mc-sgx-dcap-sys",
+ "mc-sgx-urts",
+ "test_enclave",
+]
+
+[[package]]
+name = "mc-sgx-dcap-sys"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "cargo-emit",
+ "mc-sgx-dcap-sys-types",
+]
+
+[[package]]
+name = "mc-sgx-dcap-sys-types"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "mc-sgx-urts"
 version = "0.1.0"
 dependencies = [

--- a/untrusted/Cargo.lock
+++ b/untrusted/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bindgen"
 version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +46,30 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.34.0",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 3.1.18",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -107,10 +136,34 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -139,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +211,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "lazy_static"
@@ -203,7 +272,7 @@ dependencies = [
 name = "mc-sgx-dcap-sys"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.60.1",
  "cargo-emit",
  "mc-sgx-dcap-sys-types",
 ]
@@ -212,7 +281,7 @@ dependencies = [
 name = "mc-sgx-dcap-sys-types"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.60.1",
 ]
 
 [[package]]
@@ -227,7 +296,7 @@ dependencies = [
 name = "mc-sgx-urts-sys"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.60.1",
  "cargo-emit",
  "mc-sgx-urts-sys-types",
  "test_enclave",
@@ -237,7 +306,7 @@ dependencies = [
 name = "mc-sgx-urts-sys-types"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.59.2",
  "cargo-emit",
  "test_enclave",
 ]
@@ -263,6 +332,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "peeking_take_while"
@@ -324,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,7 +417,7 @@ dependencies = [
 name = "test_enclave"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.60.1",
  "cargo-emit",
  "cc",
  "mc-sgx-urts-sys-types",
@@ -350,6 +431,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-width"

--- a/untrusted/Cargo.toml
+++ b/untrusted/Cargo.toml
@@ -4,6 +4,9 @@ members = [
     "urts",
     "urts_sys",
     "urts_sys_types",
+    "dcap",
+    "dcap/sys",
+    "dcap/sys/types",
 ]
 exclude = [
     "test_enclave",

--- a/untrusted/dcap/Cargo.toml
+++ b/untrusted/dcap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mc-sgx-dcap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mc-sgx-dcap-sys = { path = "sys" }
+mc-sgx-urts = { path = "../urts" }
+
+[dev-dependencies]
+test_enclave = { path = "../test_enclave" }

--- a/untrusted/dcap/src/lib.rs
+++ b/untrusted/dcap/src/lib.rs
@@ -99,7 +99,7 @@ impl Quote {
         if result != quote3_error_t::SGX_QL_SUCCESS {
             // There isn't any corrective action we can take if there is a
             // failure to unload the quoting enclaves
-            print!("Error in cleaning up enclave policy");
+            println!("Error in cleaning up enclaves: {:?}", result);
         }
     }
 

--- a/untrusted/dcap/src/lib.rs
+++ b/untrusted/dcap/src/lib.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Rust wrappers for DCAP (Data Center Attestation Primitives) quote
+//! generation
+
+use mc_sgx_dcap_sys::{
+    quote3_error_t, sgx_qe_cleanup_by_policy, sgx_qe_get_quote, sgx_qe_get_quote_size,
+    sgx_qe_get_target_info, sgx_ql_path_type_t, sgx_ql_set_path, sgx_report_t, sgx_target_info_t,
+};
+use mc_sgx_urts::Enclave;
+use std::ffi::CString;
+use std::mem;
+use std::mem::MaybeUninit;
+
+/// Errors generating quotes
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    // An error provided from the SGX SDK
+    SgxStatus(quote3_error_t),
+}
+
+impl From<mc_sgx_urts::Error> for Error {
+    fn from(err: mc_sgx_urts::Error) -> Self {
+        match err {
+            mc_sgx_urts::Error::SgxStatus(x) => {
+                // TODO re-think, these codes don't transfer 1:1
+                //  However SGX keeps the code separate by providing a mask on
+                //  the upper bits of a 16 bit value per the below macro
+                //  `#define SGX_???_ERROR(x) (0x0000?000|(x))`  The `?` changes
+                //  based on where the error comes from
+                let error_code = x.0;
+                let quote3_error = quote3_error_t(error_code);
+                Error::SgxStatus(quote3_error)
+            }
+            mc_sgx_urts::Error::NoReportFunction => {
+                Error::SgxStatus(quote3_error_t::SGX_QL_UNABLE_TO_GENERATE_REPORT)
+            }
+        }
+    }
+}
+
+/// A quote from the SGX interface
+pub struct Quote {
+    // Only used in tests so far
+    #[allow(dead_code)]
+    quote: Vec<u8>,
+}
+
+impl Quote {
+    /// Returns a quote for the provided [Enclave].
+    ///
+    /// # Arguments
+    /// - `enclave` The enclave to generate the quote for.
+    pub fn new(enclave: &Enclave) -> Result<Self, Error> {
+        Self::load_in_process_enclaves()?;
+        // TODO need to have a common type instead of transmuting these
+        let target_info = Self::get_target_info()?;
+        let target_info = unsafe { mem::transmute(target_info) };
+        let report = enclave.create_report(Some(&target_info))?;
+        let report = unsafe { mem::transmute(report) };
+        let quote = Self::get_quote(report);
+        Self::cleanup_in_process_enclaves();
+        quote
+    }
+
+    fn load_in_process_enclaves() -> Result<(), Error> {
+        //TODO this should be guarded by a feature and this should only be done
+        //  once, maybe lazy_static
+        for (path, enclave) in [
+            (
+                sgx_ql_path_type_t::SGX_QL_PCE_PATH,
+                "libsgx_pce.signed.so.1",
+            ),
+            (
+                sgx_ql_path_type_t::SGX_QL_QE3_PATH,
+                "libsgx_qe3.signed.so.1",
+            ),
+            (
+                sgx_ql_path_type_t::SGX_QL_IDE_PATH,
+                "libsgx_id_enclave.signed.so.1",
+            ),
+        ] {
+            Self::load_in_process_enclave(path, enclave)?
+        }
+        Ok(())
+    }
+
+    fn load_in_process_enclave(path_type: sgx_ql_path_type_t, enclave: &str) -> Result<(), Error> {
+        let path = CString::new(format!("/usr/lib/x86_64-linux-gnu/{}", enclave))
+            .unwrap_or_else(|_| panic!("Failed to convert {} to a C String", enclave));
+        let result = unsafe { sgx_ql_set_path(path_type, path.as_ptr()) };
+        match result {
+            quote3_error_t::SGX_QL_SUCCESS => Ok(()),
+            x => Err(Error::SgxStatus(x)),
+        }
+    }
+
+    fn cleanup_in_process_enclaves() {
+        let result = unsafe { sgx_qe_cleanup_by_policy() };
+        if result != quote3_error_t::SGX_QL_SUCCESS {
+            // There isn't any corrective action we can take if there is a
+            // failure to unload the quoting enclaves
+            print!("Error in cleaning up enclave policy");
+        }
+    }
+
+    fn get_target_info() -> Result<sgx_target_info_t, Error> {
+        let target_info = MaybeUninit::zeroed();
+        let mut target_info = unsafe { target_info.assume_init() };
+        let result = unsafe { sgx_qe_get_target_info(&mut target_info) };
+        match result {
+            quote3_error_t::SGX_QL_SUCCESS => Ok(target_info),
+            x => Err(Error::SgxStatus(x)),
+        }
+    }
+
+    fn get_quote(report: sgx_report_t) -> Result<Quote, Error> {
+        let mut size = 0;
+        let result = unsafe { sgx_qe_get_quote_size(&mut size) };
+        if result != quote3_error_t::SGX_QL_SUCCESS {
+            return Err(Error::SgxStatus(result));
+        }
+
+        let mut quote: Vec<u8> = vec![0; size as usize];
+        let result = unsafe { sgx_qe_get_quote(&report, size, quote.as_mut_ptr()) };
+        match result {
+            quote3_error_t::SGX_QL_SUCCESS => Ok(Quote { quote }),
+            x => Err(Error::SgxStatus(x)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_sgx_dcap_sys::{
+        quote3_error_t, sgx_qe_set_enclave_load_policy, sgx_ql_request_policy_t,
+    };
+    use mc_sgx_urts::{sgx_status_t, EnclaveBuilder};
+    use std::ptr;
+    use test_enclave::{ecall_create_report, ENCLAVE};
+
+    fn report_fn(
+        enclave: &Enclave,
+        target_info: Option<&mc_sgx_urts::sgx_target_info_t>,
+    ) -> Result<mc_sgx_urts::sgx_report_t, mc_sgx_urts::Error> {
+        let report = MaybeUninit::zeroed();
+        let mut report = unsafe { report.assume_init() };
+        let mut retval: sgx_status_t = sgx_status_t::SGX_SUCCESS;
+        let info = match target_info {
+            Some(info) => info,
+            None => ptr::null(),
+        };
+        let result = unsafe { ecall_create_report(**enclave, &mut retval, info, &mut report) };
+        match result {
+            sgx_status_t::SGX_SUCCESS => match retval {
+                sgx_status_t::SGX_SUCCESS => Ok(report),
+                x => Err(mc_sgx_urts::Error::SgxStatus(x)),
+            },
+            x => Err(mc_sgx_urts::Error::SgxStatus(x)),
+        }
+    }
+
+    #[test]
+    fn generate_quote_for_enclave() {
+        let enclave = EnclaveBuilder::new(ENCLAVE)
+            .report_fn(Some(report_fn))
+            .create()
+            .unwrap();
+        let quote = Quote::new(&enclave).unwrap();
+
+        // The quote will be dependent on the machine being ran on so we only
+        // make sure it has contents.
+        assert_ne!(quote.quote.len(), 0);
+        assert_ne!(quote.quote, vec![0; quote.quote.len()]);
+
+        // This is a work around for the
+        // [static initialization order fiasco](https://en.cppreference.com/w/cpp/language/siof)
+        // The `g_ql_global_data` in `qe_logic.cpp` (Intel DCAP code) is
+        // initialized prior to `CEnclaveMngr` in
+        // `enclave_mngr.cpp` (Intel SGX SDK).
+        // Since `CEnclaveMngr` was initialized after, it will be destroyed
+        // first. `g_ql_global_data` will try to free its enclave which
+        // calls into the destroyed `CEnclaveMngr` resulting in a
+        // memory access violation.  Setting the policy to ephemeral takes
+        // advantage of an implementation detail that will destroy the
+        // quoting enclave in `g_ql_global_data`.
+        // https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/fe200aa160bc159f92149f02e703f0b02e4348d2/QuoteGeneration/quote_wrapper/quote/qe_logic.cpp#L748
+        let result =
+            unsafe { sgx_qe_set_enclave_load_policy(sgx_ql_request_policy_t::SGX_QL_EPHEMERAL) };
+        assert_eq!(result, quote3_error_t::SGX_QL_SUCCESS);
+    }
+}

--- a/untrusted/dcap/sys/Cargo.toml
+++ b/untrusted/dcap/sys/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mc-sgx-dcap-sys"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mc-sgx-dcap-sys-types = { path = "types" }
+
+[build-dependencies]
+bindgen = "0.59.2"
+cargo-emit = "0.2.1"

--- a/untrusted/dcap/sys/Cargo.toml
+++ b/untrusted/dcap/sys/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 mc-sgx-dcap-sys-types = { path = "types" }
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/untrusted/dcap/sys/build.rs
+++ b/untrusted/dcap/sys/build.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Build the FFI function bindings for DCAP (Data Center Attestation Primitives)
+//! quote generation
+extern crate bindgen;
+use cargo_emit::rustc_link_lib;
+use std::{env, path::PathBuf};
+
+fn main() {
+    rustc_link_lib!("sgx_dcap_quoteverify");
+    rustc_link_lib!("sgx_dcap_ql");
+
+    let bindings = bindgen::Builder::default()
+        //TODO: turn this into separate generation and verification crates
+        .header_contents(
+            "dcap_qv.h",
+            "#include <sgx_dcap_quoteverify.h>\n#include <sgx_dcap_ql_wrapper.h>",
+        )
+        .blocklist_type("*")
+        .allowlist_function("sgx_.*")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Suppressing warnings from tests, see
+        // https://github.com/rust-lang/rust-bindgen/issues/1651
+        .layout_tests(false)
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").expect("Missing env.OUT_DIR"));
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/untrusted/dcap/sys/src/lib.rs
+++ b/untrusted/dcap/sys/src/lib.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! FFI functions for DCAP (Data Center Attestation Primitives) quote
+//! generation, see
+//! https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+
+pub use mc_sgx_dcap_sys_types::{
+    quote3_error_t, sgx_cpu_svn_t, sgx_isv_svn_t, sgx_pce_error_t, sgx_ql_path_type_t,
+    sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, sgx_ql_qve_collateral_t, sgx_ql_request_policy_t,
+    sgx_qv_path_type_t, sgx_report_t, sgx_target_info_t, time_t,
+};
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_sgx_dcap_sys_types::{quote3_error_t, sgx_ql_request_policy_t};
+
+    #[test]
+    fn setting_verification_load_policy_works() {
+        let result =
+            unsafe { sgx_qv_set_enclave_load_policy(sgx_ql_request_policy_t::SGX_QL_DEFAULT) };
+        assert_eq!(result, quote3_error_t::SGX_QL_SUCCESS);
+    }
+
+    #[test]
+    fn setting_generation_load_policy_works() {
+        let result =
+            unsafe { sgx_qe_set_enclave_load_policy(sgx_ql_request_policy_t::SGX_QL_DEFAULT) };
+        assert_eq!(result, quote3_error_t::SGX_QL_SUCCESS);
+    }
+}

--- a/untrusted/dcap/sys/types/Cargo.toml
+++ b/untrusted/dcap/sys/types/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.60.1"

--- a/untrusted/dcap/sys/types/Cargo.toml
+++ b/untrusted/dcap/sys/types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mc-sgx-dcap-sys-types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[build-dependencies]
+bindgen = "0.59.2"

--- a/untrusted/dcap/sys/types/build.rs
+++ b/untrusted/dcap/sys/types/build.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Build the FFI type bindings for DCAP (Data Center Attestation Primitives)
+//! quote generation
+extern crate bindgen;
+use std::{env, path::PathBuf};
+
+fn main() {
+    let bindings = bindgen::Builder::default()
+        //TODO: turn this into separate generation and verification crates
+        .header_contents(
+            "dcap_qv.h",
+            "#include <sgx_dcap_quoteverify.h>\n#include <sgx_dcap_ql_wrapper.h>",
+        )
+        .blocklist_function("*")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Suppressing warnings from tests, see
+        // https://github.com/rust-lang/rust-bindgen/issues/1651
+        .layout_tests(false)
+        // Avoid debug as dcap has packed structs which will give error E0133
+        .no_debug("*")
+        .newtype_enum("_sgx_ql_request_policy")
+        .newtype_enum("_quote3_error_t")
+        .newtype_enum("sgx_ql_path_type_t")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/untrusted/dcap/sys/types/build.rs
+++ b/untrusted/dcap/sys/types/build.rs
@@ -17,10 +17,9 @@ fn main() {
         // Suppressing warnings from tests, see
         // https://github.com/rust-lang/rust-bindgen/issues/1651
         .layout_tests(false)
-        // Avoid debug as dcap has packed structs which will give error E0133
-        .no_debug("*")
         .newtype_enum("_sgx_ql_request_policy")
         .newtype_enum("_quote3_error_t")
+        .no_debug("_quote3_error_t")
         .newtype_enum("sgx_ql_path_type_t")
         .generate()
         .expect("Unable to generate bindings");

--- a/untrusted/dcap/sys/types/src/lib.rs
+++ b/untrusted/dcap/sys/types/src/lib.rs
@@ -9,4 +9,15 @@
     non_upper_case_globals,
     clippy::missing_safety_doc
 )]
+
+use std::fmt;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+impl fmt::Debug for _quote3_error_t {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Hexify the output.  The default debug output is
+        // `_quote3_error_t(<int>)` while the error code definitions are in hex.
+        write!(fmt, "_quote3_error_t({:x})", self.0)
+    }
+}

--- a/untrusted/dcap/sys/types/src/lib.rs
+++ b/untrusted/dcap/sys/types/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! FFI types for DCAP (Data Center Attestation Primitives) quote generation,
+//! see
+//! https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf
+
+#![allow(
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals,
+    clippy::missing_safety_doc
+)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/untrusted/test_enclave/Cargo.toml
+++ b/untrusted/test_enclave/Cargo.toml
@@ -13,4 +13,4 @@ default = []
 [build-dependencies]
 cargo-emit = "0.2.1"
 cc = "1.0.73"
-bindgen = "0.59.2"
+bindgen = "0.60.1"

--- a/untrusted/urts/src/lib.rs
+++ b/untrusted/urts/src/lib.rs
@@ -1,11 +1,8 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! Provides rust wrappers for the SGX untrusted runtime system (uRTS) functionality
 
-pub use mc_sgx_urts_sys::{sgx_report_t, sgx_target_info_t};
-
-use mc_sgx_urts_sys::{
-    sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave, sgx_enclave_id_t, sgx_status_t,
-};
+use mc_sgx_urts_sys::{sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave, sgx_enclave_id_t};
+pub use mc_sgx_urts_sys::{sgx_report_t, sgx_status_t, sgx_target_info_t};
 use std::ops::Deref;
 use std::{fmt, os::raw::c_int, ptr};
 

--- a/untrusted/urts/src/lib.rs
+++ b/untrusted/urts/src/lib.rs
@@ -1,8 +1,9 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! Provides rust wrappers for the SGX untrusted runtime system (uRTS) functionality
 
-use mc_sgx_urts_sys::{sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave, sgx_enclave_id_t};
 pub use mc_sgx_urts_sys::{sgx_report_t, sgx_status_t, sgx_target_info_t};
+
+use mc_sgx_urts_sys::{sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave, sgx_enclave_id_t};
 use std::ops::Deref;
 use std::{fmt, os::raw::c_int, ptr};
 

--- a/untrusted/urts_sys/Cargo.toml
+++ b/untrusted/urts_sys/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 mc-sgx-urts-sys-types = { path = "../urts_sys_types" }
 
 [build-dependencies]
-bindgen = "0.59.2"
+bindgen = "0.60.1"
 cargo-emit = "0.2.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Adds an initial attempt at creating an enclave quote.

This creates an enclave quote utilizing the in process quote generation, https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf

This will only work on HW SGX after building and installing the packages,  https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/QuoteGeneration#build-the-intelr-sgx-dcap-quote-generation-library-and-the-intelr-sgx-default-quote-provider-library-package.