### PR TITLE
Add `mc-sgx-core-build` crate

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -201,10 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-core-build"
+version = "0.1.0"
+
+[[package]]
 name = "mc-sgx-core-sys-types"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "mc-sgx-core-build",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
-	"sys/types",
+    "sys/types",
+    "build",
 ]
 
 [profile.dev]

--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "mc-sgx-core-build"
+version = "0.1.0"
+edition = "2021"

--- a/core/build/README.md
+++ b/core/build/README.md
@@ -5,9 +5,6 @@ This crate provides common logic to build and link against the Intel SGX SDK
 ## Table of Contents
 
 - [License](#license)
-- [Build Instructions](#build-instructions)
-- [Intel SGX SDK](#intel-sgx-sdk)
-- [Features](#features)
 - [References](#references)
 
 ## License

--- a/core/build/README.md
+++ b/core/build/README.md
@@ -1,0 +1,20 @@
+# Common build logic for SGX libraries
+
+This crate provides common logic to build and link against the Intel SGX SDK
+
+## Table of Contents
+
+- [License](#license)
+- [Build Instructions](#build-instructions)
+- [Intel SGX SDK](#intel-sgx-sdk)
+- [Features](#features)
+- [References](#references)
+
+## License
+
+Look for the *LICENSE* file at the root of the repo for more information.
+
+## References
+
+- <https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/docs/Intel_SGX_Enclave_Common_Loader_API_Reference.pdf>
+- <https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package>

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+#![doc = include_str!("../README.md")]
+
+use std::{env, path::PathBuf};
+
+static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
+
+/// Return the SGX library path.
+///
+/// Will first attempt to look at the environment variable `SGX_SDK`, if that
+/// isn't present then `/opt/intel/sgxsdk` will be used.
+pub fn sgx_library_path() -> String {
+    env::var("SGX_SDK").unwrap_or_else(|_| DEFAULT_SGX_SDK_PATH.into())
+}
+
+/// Return the build output path.
+pub fn build_output_path() -> PathBuf {
+    PathBuf::from(env::var("OUT_DIR").expect("Missing env.OUT_DIR"))
+}
+
+/// Return the SGX library suffix
+///
+/// Some SGX libraries have a suffix for example `sgx_trts.a` versus
+/// `sgx_trts_sim.a`.  This will result the suffix based on the presence of the
+/// feature `hw`.
+pub fn sgx_library_suffix() -> &'static str {
+    // See https://doc.rust-lang.org/cargo/reference/features.html#build-scripts
+    // for description of `CARGO_FEATURE_<name>`
+    match env::var("CARGO_FEATURE_HW") {
+        Ok(_) => "",
+        _ => "_sim",
+    }
+}

--- a/core/sys/types/Cargo.toml
+++ b/core/sys/types/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [build-dependencies]
 bindgen = "0.60.1"
+mc-sgx-core-build = { path = "../../build" }

--- a/trusted/trts/sys/Cargo.toml
+++ b/trusted/trts/sys/Cargo.toml
@@ -13,3 +13,4 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
+mc-sgx-core-build = { path = "../../../core/build" }

--- a/trusted/trts/sys/Cargo.toml
+++ b/trusted/trts/sys/Cargo.toml
@@ -13,4 +13,5 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
+
 mc-sgx-core-build = { path = "../../../core/build" }

--- a/trusted/trts/sys/build.rs
+++ b/trusted/trts/sys/build.rs
@@ -2,35 +2,25 @@
 
 //! Builds the FFI function bindings for trts (trusted runtime system) of the
 //! Intel SGX SDK
-extern crate bindgen;
+use bindgen::Builder;
 use cargo_emit::{rustc_link_lib, rustc_link_search};
-use std::{env, path::PathBuf};
-
-static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
-
-#[cfg(feature = "hw")]
-const SGX_SUFFIX: &str = "";
-#[cfg(not(feature = "hw"))]
-const SGX_SUFFIX: &str = "_sim";
-
-fn sgx_library_path() -> String {
-    env::var("SGX_SDK").unwrap_or_else(|_| DEFAULT_SGX_SDK_PATH.into())
-}
 
 fn main() {
-    rustc_link_lib!(&format!("sgx_trts{}", SGX_SUFFIX));
-    rustc_link_search!(&format!("{}/lib64", sgx_library_path()));
+    let sgx_library_path = mc_sgx_core_build::sgx_library_path();
+    let sgx_suffix = mc_sgx_core_build::sgx_library_suffix();
+    rustc_link_lib!(&format!("sgx_trts{}", sgx_suffix));
+    rustc_link_search!(&format!("{}/lib64", &sgx_library_path));
 
-    let bindings = bindgen::Builder::default()
+    let bindings = Builder::default()
         .header_contents("trts.h", "#include <sgx_trts.h>")
-        .clang_arg(&format!("-I{}/include", sgx_library_path()))
+        .clang_arg(&format!("-I{}/include", &sgx_library_path))
         .blocklist_type("*")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .ctypes_prefix("core::ffi")
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").expect("Missing env.OUT_DIR"));
+    let out_path = mc_sgx_core_build::build_output_path();
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/untrusted/Cargo.lock
+++ b/untrusted/Cargo.lock
@@ -463,10 +463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-core-build"
+version = "0.1.0"
+
+[[package]]
 name = "mc-sgx-core-sys-types"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.60.1",
+ "mc-sgx-core-build",
 ]
 
 [[package]]
@@ -493,6 +498,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen 0.60.1",
  "cargo-emit",
+ "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
  "mc-sgx-urts-sys-types",
  "test_enclave",
@@ -504,6 +510,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen 0.60.1",
  "cargo-emit",
+ "mc-sgx-core-build",
  "test_enclave",
 ]
 
@@ -857,6 +864,7 @@ dependencies = [
  "bindgen 0.60.1",
  "cargo-emit",
  "cc",
+ "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
  "mc-sgx-urts-sys-types",
  "rand",

--- a/untrusted/test_enclave/Cargo.toml
+++ b/untrusted/test_enclave/Cargo.toml
@@ -17,3 +17,4 @@ cc = "1.0.73"
 bindgen = "0.60.1"
 rsa = "0.6.1"
 rand = "0.8.5"
+mc-sgx-core-build = { path = "../../core/build" }

--- a/untrusted/test_enclave/Cargo.toml
+++ b/untrusted/test_enclave/Cargo.toml
@@ -17,4 +17,5 @@ cc = "1.0.73"
 bindgen = "0.60.1"
 rsa = "0.6.1"
 rand = "0.8.5"
+
 mc-sgx-core-build = { path = "../../core/build" }

--- a/untrusted/urts/sys/Cargo.toml
+++ b/untrusted/urts/sys/Cargo.toml
@@ -14,6 +14,7 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
+
 mc-sgx-core-build = { path = "../../../core/build" }
 
 [dev-dependencies]

--- a/untrusted/urts/sys/Cargo.toml
+++ b/untrusted/urts/sys/Cargo.toml
@@ -14,6 +14,7 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
+mc-sgx-core-build = { path = "../../../core/build" }
 
 [dev-dependencies]
 test_enclave = { path = "../../test_enclave" }

--- a/untrusted/urts/sys/build.rs
+++ b/untrusted/urts/sys/build.rs
@@ -1,35 +1,25 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 
 //! Builds the FFI bindings for the untrusted side of the Intel SGX SDK
-extern crate bindgen;
+use bindgen::Builder;
 use cargo_emit::{rustc_link_lib, rustc_link_search};
-use std::{env, path::PathBuf};
-
-static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
-
-#[cfg(feature = "hw")]
-const SGX_SUFFIX: &str = "";
-#[cfg(not(feature = "hw"))]
-const SGX_SUFFIX: &str = "_sim";
-
-fn sgx_library_path() -> String {
-    env::var("SGX_SDK").unwrap_or_else(|_| DEFAULT_SGX_SDK_PATH.into())
-}
 
 fn main() {
-    rustc_link_lib!(&format!("sgx_urts{}", SGX_SUFFIX));
-    rustc_link_lib!(&format!("sgx_launch{}", SGX_SUFFIX));
-    rustc_link_search!(&format!("{}/lib64", sgx_library_path()));
+    let sgx_library_path = mc_sgx_core_build::sgx_library_path();
+    let sgx_suffix = mc_sgx_core_build::sgx_library_suffix();
+    rustc_link_lib!(&format!("sgx_urts{}", sgx_suffix));
+    rustc_link_lib!(&format!("sgx_launch{}", sgx_suffix));
+    rustc_link_search!(&format!("{}/lib64", sgx_library_path));
 
-    let bindings = bindgen::Builder::default()
+    let bindings = Builder::default()
         .header_contents("urts.h", "#include <sgx_urts.h>")
-        .clang_arg(&format!("-I{}/include", sgx_library_path()))
+        .clang_arg(&format!("-I{}/include", sgx_library_path))
         .blocklist_type("*")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .generate()
         .expect("Unable to generate bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").expect("Missing env.OUT_DIR"));
+    let out_path = mc_sgx_core_build::build_output_path();
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");

--- a/untrusted/urts/sys/types/Cargo.toml
+++ b/untrusted/urts/sys/types/Cargo.toml
@@ -7,11 +7,10 @@ edition = "2021"
 sw = []
 default = ["sw"]
 
-[dependencies]
+[dev-dependencies]
+test_enclave = { path = "../../../test_enclave" }
 
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-
-[dev-dependencies]
-test_enclave = { path = "../../../test_enclave" }
+mc-sgx-core-build = { path = "../../../../core/build" }

--- a/untrusted/urts/sys/types/Cargo.toml
+++ b/untrusted/urts/sys/types/Cargo.toml
@@ -13,4 +13,5 @@ test_enclave = { path = "../../../test_enclave" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
+
 mc-sgx-core-build = { path = "../../../../core/build" }

--- a/untrusted/urts/sys/types/build.rs
+++ b/untrusted/urts/sys/types/build.rs
@@ -4,8 +4,6 @@
 use bindgen::{callbacks::ParseCallbacks, Builder};
 use std::{env, path::PathBuf};
 
-static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
-
 #[derive(Debug)]
 struct Callbacks;
 
@@ -19,14 +17,11 @@ impl ParseCallbacks for Callbacks {
     }
 }
 
-fn sgx_library_path() -> String {
-    env::var("SGX_SDK").unwrap_or_else(|_| DEFAULT_SGX_SDK_PATH.into())
-}
-
 fn main() {
+    let sgx_library_path = mc_sgx_core_build::sgx_library_path();
     let bindings = Builder::default()
         .header_contents("urts_types.h", "#include <sgx_urts.h>")
-        .clang_arg(&format!("-I{}/include", sgx_library_path()))
+        .clang_arg(&format!("-I{}/include", sgx_library_path))
         .blocklist_function("*")
         .allowlist_type("sgx_enclave_id_t")
         .allowlist_type("sgx_launch_token_t")


### PR DESCRIPTION
Add the `mc-sgx-core-build` crate to hold common build utilities used
with other SGX crates.