### PR TITLE
Add ability to build SGX SDK when building crates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,3 +28,41 @@ jobs:
       - name: Setup rust toolchain
         run: rustup show
       - run: cargo test --release --locked
+  build_vendored:
+    # The Large runner is used here due to minimize SGX SDK compile time
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/rust-sgx-base:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup rust toolchain
+        run: rustup show
+      - name: Install SGX SDK tools
+        # packages taken from
+        # https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package
+        run: apt-get update && apt-get -y install 
+          build-essential 
+          ocaml 
+          ocamlbuild 
+          automake 
+          autoconf 
+          libtool 
+          wget 
+          python-is-python3 
+          libssl-dev 
+          git 
+          cmake 
+          perl 
+          libssl-dev 
+          libcurl4-openssl-dev 
+          protobuf-compiler 
+          libprotobuf-dev 
+          debhelper 
+          cmake 
+          reprepro 
+          unzip 
+          lsb-release
+      - name: Install mitigation binutils
+        run: wget https://download.01.org/intel-sgx/sgx-linux/2.17/as.ld.objdump.r4.tar.gz -P /tmp/binutils && 
+          tar -xzf /tmp/binutils/as.ld.objdump.r4.tar.gz --directory /tmp/binutils/ external/toolset/ubuntu20.04 && 
+          cp /tmp/binutils/external/toolset/ubuntu20.04/* /usr/local/bin/
+      - run: cargo build --release --locked --features vendored

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all --check
   clippy:
     runs-on: [self-hosted, Linux, small]
     container: mobilecoin/rust-sgx-base:latest
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
-      - run: cargo clippy --all --all-features --locked -- -D warnings
+      # Intentionally not using `--all-features` here as the vendored feature
+      # takes a long time, only building it.
+      - run: cargo clippy --all --locked -- -D warnings
   nono:
     runs-on: [self-hosted, Linux, small]
     container: mobilecoin/rust-sgx-base:latest
@@ -42,5 +44,5 @@ jobs:
       - run: |
           cargo metadata --no-deps --format-version=1 | \
             jq -r '.packages[].name' | \
-            grep -v -e mc-sgx-core-build -e mc-sgx-quote-verify -e mc-sgx-urts | \
+            grep -v -e mc-sgx-quote-verify -e mc-sgx-urts | \
             xargs -n1 sh -c 'cargo nono check --package $0 || exit 255'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cexpr"
@@ -377,6 +380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +408,21 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -451,6 +479,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +504,15 @@ name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -497,6 +545,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +575,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,8 +610,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "mc-sgx-core-build"
 version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "mc-sgx-core-source",
+]
 
 [[package]]
 name = "mc-sgx-core-ffi-types"
@@ -531,6 +629,13 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "mc-sgx-core-build",
+]
+
+[[package]]
+name = "mc-sgx-core-source"
+version = "0.1.0"
+dependencies = [
+ "git2",
 ]
 
 [[package]]
@@ -735,6 +840,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +900,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "pkcs1"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +936,12 @@ dependencies = [
  "der 0.6.0",
  "spki 0.6.0",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1115,10 +1251,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -1131,6 +1297,24 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 resolver = "2"
 members = [
     "core/ffi/types",
-    "core/build",
     "crypto/ffi/types",
     "crypto/ffi",
     "panic/abort",
@@ -14,7 +13,12 @@ members = [
     "urts/ffi",
     "urts/ffi/types",
 ]
+
 exclude = [
+    # Exclude build and source so they aren't built by default, only when
+    # specifically required
+    "core/build",
+    "core/source",
     "test_enclave",
 ]
 

--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -2,3 +2,11 @@
 name = "mc-sgx-core-build"
 version = "0.1.0"
 edition = "2021"
+
+[features]
+vendored = ['mc-sgx-core-source']
+
+[dependencies]
+cfg-if = "1.0.0"
+mc-sgx-core-source = { path = "../source" , optional = true }
+

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -4,14 +4,21 @@
 
 use std::{env, path::PathBuf};
 
-static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
-
 /// Return the SGX library path.
 ///
-/// Will first attempt to look at the environment variable `SGX_SDK`, if that
-/// isn't present then `/opt/intel/sgxsdk` will be used.
+/// When `vendored` feature is on this will provide the path from the
+/// vendored build.
+///
+/// Otherwise will first attempt to look at the environment variable `SGX_SDK`,
+/// if that isn't present then `/opt/intel/sgxsdk` will be used.
 pub fn sgx_library_path() -> String {
-    env::var("SGX_SDK").unwrap_or_else(|_| DEFAULT_SGX_SDK_PATH.into())
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "vendored")] {
+            mc_sgx_core_source::sgx_library_path()
+        } else {
+            env::var("SGX_SDK").unwrap_or_else(|_| "/opt/intel/sgxsdk".into())
+        }
+    }
 }
 
 /// Return the build output path.

--- a/core/source/Cargo.toml
+++ b/core/source/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mc-sgx-core-source"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+git2 = "0.15.0"

--- a/core/source/build.rs
+++ b/core/source/build.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Build the linux SGX SDK
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const TAG: &str = "sgx_2.17";
+
+fn main() {
+    let build_dir = out_dir().join("linux-sgx");
+    clone_sdk(&build_dir);
+    build_sdk(&build_dir);
+    write_out_sgx_sdk_path(&build_dir);
+}
+
+/// Return the output path for the build
+fn out_dir() -> PathBuf {
+    PathBuf::from(env::var("OUT_DIR").expect("Missing env.OUT_DIR"))
+}
+
+/// Clone the Intel SGX SDK source code.
+///
+/// Unfortunately the Intel SGX SDK does an in source build and it doesn't look
+/// like there is any way to do an out of source build.  To minimize a dirty
+/// git repo, we clone the SDK into the build directory instead of vendoring
+/// it in as a submodule.
+///
+/// The internal build steps of the SGX SDK will download files so it's already
+/// dependent on online inputs.
+///
+/// # Arguments
+///
+/// * `build_dir` - The directory to clone the repository to.  The repository
+///   will end up being in `build_dir/repo_name`
+fn clone_sdk<P: AsRef<Path>>(build_dir: &P) {
+    let repo = if build_dir.as_ref().exists() {
+        git2::Repository::open(build_dir).expect("Unable to open the linux SGX repository")
+    } else {
+        git2::Repository::clone("https://github.com/intel/linux-sgx.git", build_dir)
+            .expect("Unable to clone the linux SGX repository")
+    };
+    repo.set_head(&format!("refs/tags/{}", TAG))
+        .expect("Unable to set to the tag");
+    repo.checkout_head(None)
+        .expect("Unable to checkout git repo to specified HEAD");
+}
+
+/// Build the Intel SGX SDK, the `sdk_install_pkg`.
+///
+/// # Arguments
+///
+/// * `sdk_source_dir` - The directory of the SGX SDK source files to perform
+///   the build on.
+fn build_sdk<P: AsRef<Path>>(sdk_source_dir: &P) {
+    let mut command = Command::new("make");
+    command.current_dir(sdk_source_dir).arg("preparation");
+    run_command(command);
+    let mut command = Command::new("make");
+    //TODO not fond of the unlimited "-j" here, but on my machine build
+    // times went from 8min down to 2min.  The unlimited "-j" can really
+    // bog down the machine
+    command
+        .current_dir(sdk_source_dir)
+        .arg("sdk_install_pkg")
+        .arg("-j");
+    run_command(command);
+}
+
+/// Write out the vendored SGX SDK path to an intermediate file
+/// `sgx_sdk_path.txt`
+///
+/// Due to the way the Cargo does builds, the main way to communicate between
+/// a build script and the item being built is via files.  As such this will
+/// write out the path to the build SGX SDK to a file that the library can
+/// include.
+///
+/// # Arguments
+///
+/// * `sdk_source_dir` - The directory of the SGX SDK source files
+fn write_out_sgx_sdk_path<P: AsRef<Path>>(sdk_build_dir: &P) {
+    let sgx_sdk_path = sdk_build_dir
+        .as_ref()
+        .join("linux/installer/common/sdk/output/package");
+    let out_dir = out_dir();
+    fs::write(
+        out_dir.join("sgx_sdk_path.txt"),
+        sgx_sdk_path
+            .to_str()
+            .expect("Invalid UTF-8 in SGX SDK path"),
+    )
+    .expect("Failed to write SGX SDK path to file");
+}
+
+/// Run a command that is expected to always succeed and panic if it fails.
+///
+/// # Arguments
+///
+/// * `command` - The command to run
+fn run_command(mut command: Command) {
+    let status = command.status();
+    match status {
+        Ok(status) => {
+            if status.success() {
+                return;
+            }
+            panic!("Exit code {}", status);
+        }
+        Err(fail) => panic!("Failed with: {}", fail),
+    }
+}

--- a/core/source/src/lib.rs
+++ b/core/source/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+const SGX_SDK_PATH: &str = include_str!(concat!(env!("OUT_DIR"), "/sgx_sdk_path.txt"));
+
+/// Returns the library path for the vendored built SGX SDK
+pub fn sgx_library_path() -> String {
+    SGX_SDK_PATH.to_string()
+}

--- a/crypto/ffi/Cargo.toml
+++ b/crypto/ffi/Cargo.toml
@@ -3,6 +3,9 @@ name = "mc-sgx-crypto-ffi"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+vendored = ['mc-sgx-core-build/vendored']
+
 [dependencies]
 mc-sgx-core-ffi-types = { path = "../../core/ffi/types" }
 mc-sgx-crypto-ffi-types = { path = "types" }

--- a/crypto/ffi/build.rs
+++ b/crypto/ffi/build.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2022 The MobileCoin Foundation
-//! Builds the FFI function bindings for trts (trusted runtime system) of the
-//! Intel SGX SDK
+//! Builds the FFI function bindings for crypto of the Intel SGX SDK
 
 use bindgen::Builder;
 use cargo_emit::{rustc_link_lib, rustc_link_search};


### PR DESCRIPTION
The `vendored` feature has been added.  This feature allows for the SDK
to be downloaded and built when the SGX crates are built.