### PR TITLE
Consolidate ParseCallbacks and Builder to common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,9 @@ dependencies = [
 [[package]]
 name = "mc-sgx-core-build"
 version = "0.1.0"
+dependencies = [
+ "bindgen",
+]
 
 [[package]]
 name = "mc-sgx-core-ffi-types"

--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -2,3 +2,6 @@
 name = "mc-sgx-core-build"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+bindgen = "0.60.1"

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -2,9 +2,56 @@
 
 #![doc = include_str!("../README.md")]
 
+use bindgen::{callbacks::ParseCallbacks, Builder, EnumVariation};
 use std::{env, path::PathBuf};
 
 static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
+
+/// Provides a default [bindgen::callbacks::ParserCallbacks::item_name]
+/// implementation that works with most SGX types.
+///
+/// # Arguments
+/// * `name` - The name of the type to determine the bindgen name of.
+pub fn sgx_item_name(name: &str) -> Option<String> {
+    if name.starts_with("_sgx") {
+        Some(name[1..].to_owned())
+    } else if name.starts_with('_') {
+        Some(format!("sgx{}", name))
+    } else {
+        None
+    }
+}
+
+/// Returns a builder configured with the defaults for using bindgen with the
+/// SGX libraries.
+pub fn sgx_builder() -> Builder {
+    Builder::default()
+        .derive_copy(true)
+        .derive_debug(true)
+        .derive_default(true)
+        .derive_eq(true)
+        .derive_hash(true)
+        .derive_ord(true)
+        .derive_partialeq(true)
+        .derive_partialord(true)
+        .default_enum_style(EnumVariation::Consts)
+        .prepend_enum_name(false)
+        .use_core()
+        .ctypes_prefix("core::ffi")
+        .allowlist_recursively(false)
+}
+
+/// SGXParseCallbacks to be used with [bindgen::Builder::parse_callbacks]
+///
+/// This provides a default implementation for most of the SGX libraries
+#[derive(Debug)]
+pub struct SGXParseCallbacks;
+
+impl ParseCallbacks for SGXParseCallbacks {
+    fn item_name(&self, name: &str) -> Option<String> {
+        sgx_item_name(name)
+    }
+}
 
 /// Return the SGX library path.
 ///

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -7,12 +7,17 @@ use std::{env, path::PathBuf};
 
 static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
 
+/// Normalizes a type encountered by bindgen
+///
 /// Provides a default [bindgen::callbacks::ParserCallbacks::item_name]
 /// implementation that works with most SGX types.
+/// The type should come back in the form of `sgx_<main_text_from_c_interface>`
+///
+/// Returns `None` if the type is already normalized
 ///
 /// # Arguments
 /// * `name` - The name of the type to determine the bindgen name of.
-pub fn sgx_item_name(name: &str) -> Option<String> {
+pub fn sgx_normalize_item_name(name: &str) -> Option<String> {
     if name.starts_with("_sgx") {
         Some(name[1..].to_owned())
     } else if name.starts_with('_') {
@@ -45,11 +50,11 @@ pub fn sgx_builder() -> Builder {
 ///
 /// This provides a default implementation for most of the SGX libraries
 #[derive(Debug)]
-pub struct SGXParseCallbacks;
+pub struct SgxParseCallbacks;
 
-impl ParseCallbacks for SGXParseCallbacks {
+impl ParseCallbacks for SgxParseCallbacks {
     fn item_name(&self, name: &str) -> Option<String> {
-        sgx_item_name(name)
+        sgx_normalize_item_name(name)
     }
 }
 

--- a/core/ffi/types/build.rs
+++ b/core/ffi/types/build.rs
@@ -1,61 +1,37 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! Builds the FFI type bindings for the common SGX SDK types
 
-use bindgen::{callbacks::ParseCallbacks, Builder};
-
-// Types that don't have an SGX qualifier.
-//
-// These types are of the form <name> and later typedefed to an `sgx_<name>`.
-//
-// ```C
-//      typedef struct _foo_name {
-//          int a;
-//          float b;
-//      } sgx_foo_name;
-// ```
-//
-// To keep the noise out of the bindings, we use the underlying type and tell
-// bindgen to map directly to `sgx_<name>` version.
-const ALLOWED_UNDERLYING_TYPES: &[&str] = &[
-    "_status_t",
-    "_target_info_t",
-    "_attributes_t",
-    "_report_t",
-    "_key_request_t",
-];
-
-#[derive(Debug)]
-struct Callbacks;
-
-impl ParseCallbacks for Callbacks {
-    fn item_name(&self, name: &str) -> Option<String> {
-        if name.starts_with("_sgx") {
-            Some(name[1..].to_owned())
-        } else if name.starts_with('_') {
-            Some(format!("sgx{}", name))
-        } else {
-            None
-        }
-    }
-}
+use mc_sgx_core_build::SGXParseCallbacks;
 
 fn main() {
     let sgx_library_path = mc_sgx_core_build::sgx_library_path();
-    let mut builder = Builder::default()
+    let builder = mc_sgx_core_build::sgx_builder()
         .header_contents(
             "core_types.h",
             "#include <sgx_error.h>\n#include <sgx_report.h>",
         )
         .clang_arg(&format!("-I{}/include", sgx_library_path))
         .newtype_enum("_status_t")
-        .parse_callbacks(Box::new(Callbacks))
-        .ctypes_prefix("core::ffi")
-        .use_core()
-        .allowlist_type("sgx_key_128bit_t");
-
-    for t in ALLOWED_UNDERLYING_TYPES.iter() {
-        builder = builder.allowlist_type(t)
-    }
+        .parse_callbacks(Box::new(SGXParseCallbacks))
+        .allowlist_type("sgx_key_128bit_t")
+        .allowlist_type("sgx_mac_t")
+        .allowlist_type("sgx_isvfamily_id_t")
+        .allowlist_type("sgx_isv_svn_t")
+        .allowlist_type("sgx_isvext_prod_id_t")
+        .allowlist_type("sgx_misc_select_t")
+        .allowlist_type("_sgx_cpu_svn_t")
+        .allowlist_type("sgx_prod_id_t")
+        .allowlist_type("sgx_config_id_t")
+        .allowlist_type("_sgx_measurement_t")
+        .allowlist_type("sgx_config_svn_t")
+        .allowlist_type("_sgx_key_id_t")
+        .allowlist_type("_report_body_t")
+        .allowlist_type("_sgx_report_data_t")
+        .allowlist_type("_status_t")
+        .allowlist_type("_target_info_t")
+        .allowlist_type("_attributes_t")
+        .allowlist_type("_report_t")
+        .allowlist_type("_key_request_t");
 
     let bindings = builder.generate().expect("Unable to generate bindings");
 


### PR DESCRIPTION
Adds an `SGXParseCallbacks` struct that can be used in a `Builder`.
Adds a function, `sgx_builder()`  to provide a pre-configured `Builder`