### PR TITLE
Fix dependabot for directory layout

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,22 +1,12 @@
 version: 2
 updates:
 - package-ecosystem: cargo
-  directory: "/core"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: cargo
-  directory: "/untrusted"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: cargo
-  directory: "/trusted"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    # Check for updates to GitHub Actions every weekday
-    interval: "daily"
+    interval: daily
+  open-pull-requests-limit: 25
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
When 80d4a87bab460bc32cb24a9a29c7d595f0178f6e came in the
`dependabot.yaml` file was not updated for the new directory layout.
Now the `dependabot.yaml` takes into account this new directory layout.