### PR TITLE
Make urts functions explicit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,9 @@ dependencies = [
 name = "mc-sgx-urts"
 version = "0.1.0"
 dependencies = [
+ "mc-sgx-core-sys-types",
  "mc-sgx-urts-sys",
+ "mc-sgx-urts-sys-types",
  "test_enclave",
 ]
 
@@ -629,6 +631,7 @@ dependencies = [
  "bindgen",
  "cargo-emit",
  "mc-sgx-core-build",
+ "mc-sgx-core-sys-types",
  "test_enclave",
 ]
 

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -44,6 +44,7 @@ pub fn sgx_builder() -> Builder {
         .use_core()
         .ctypes_prefix("core::ffi")
         .allowlist_recursively(false)
+        .parse_callbacks(Box::new(SgxParseCallbacks))
 }
 
 /// SGXParseCallbacks to be used with [bindgen::Builder::parse_callbacks]

--- a/core/sys/types/build.rs
+++ b/core/sys/types/build.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! Builds the FFI type bindings for the common SGX SDK types
 
-use mc_sgx_core_build::SgxParseCallbacks;
-
 // The types to generate bindings for.
 //
 // To keep the noise out of the bindings, we use the underlying type and tell
@@ -45,8 +43,7 @@ fn main() {
             "#include <sgx_error.h>\n#include <sgx_report.h>",
         )
         .clang_arg(&format!("-I{}/include", sgx_library_path))
-        .newtype_enum("_status_t")
-        .parse_callbacks(Box::new(SgxParseCallbacks));
+        .newtype_enum("_status_t");
 
     for t in CORE_TYPES.iter() {
         builder = builder.allowlist_type(t)

--- a/urts/Cargo.toml
+++ b/urts/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 mc-sgx-urts-sys = { path = "sys", default-features = false }
+mc-sgx-core-sys-types = { path = "../core/sys/types" }
+mc-sgx-urts-sys-types = { path = "sys/types" }
 
 [features]
 hw = ["mc-sgx-urts-sys/hw"]

--- a/urts/src/lib.rs
+++ b/urts/src/lib.rs
@@ -2,9 +2,9 @@
 //! Provides rust wrappers for the SGX untrusted runtime system (uRTS)
 //! functionality
 
-use mc_sgx_urts_sys::{
-    sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave, sgx_enclave_id_t, sgx_status_t,
-};
+use mc_sgx_core_sys_types::sgx_status_t;
+use mc_sgx_urts_sys::{sgx_create_enclave_from_buffer_ex, sgx_destroy_enclave};
+use mc_sgx_urts_sys_types::sgx_enclave_id_t;
 use std::{ops::Deref, os::raw::c_int, ptr};
 
 #[derive(Debug, PartialEq, Eq)]

--- a/urts/sys/README.md
+++ b/urts/sys/README.md
@@ -1,6 +1,14 @@
-# FFI Bindings to the untrusted SGX functionality
+# MobileCoin's FFI Bindings to the untrusted SGX functionality
 
-Provides the rust bindings, and linking, to the SGX SDK untrusted C functions.
+[![mc-sgx-urts-sys][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+Provides the rust function bindings to the `sgx_urts` library.
 
 ## Table of Contents
 
@@ -40,3 +48,15 @@ linked in.
 
 - <https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/docs/Intel_SGX_Enclave_Common_Loader_API_Reference.pdf>
 - <https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package>
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-urts-sys.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/aead
+[license-image]: https://img.shields.io/crates/l/mc-sgx-urts-sys?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-urts-sys?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-urts-sys
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-urts-sys/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-urts-sys

--- a/urts/sys/build.rs
+++ b/urts/sys/build.rs
@@ -1,8 +1,16 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 
 //! Builds the FFI bindings for the untrusted side of the Intel SGX SDK
-use bindgen::Builder;
 use cargo_emit::{rustc_link_lib, rustc_link_search};
+
+const URTS_FUNCTIONS: &[&str] = &[
+    "sgx_create_enclave",
+    "sgx_create_enclave_ex",
+    "sgx_create_enclave_from_buffer_ex",
+    "sgx_create_encrypted_enclave",
+    "sgx_destroy_enclave",
+    "sgx_get_target_info",
+];
 
 fn main() {
     let sgx_library_path = mc_sgx_core_build::sgx_library_path();
@@ -11,16 +19,18 @@ fn main() {
     rustc_link_lib!(&format!("sgx_launch{}", sgx_suffix));
     rustc_link_search!(&format!("{}/lib64", sgx_library_path));
 
-    let bindings = Builder::default()
+    let mut builder = mc_sgx_core_build::sgx_builder()
         .header_contents("urts.h", "#include <sgx_urts.h>")
-        .clang_arg(&format!("-I{}/include", sgx_library_path))
-        .blocklist_type("*")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .generate()
-        .expect("Unable to generate bindings");
+        .clang_arg(&format!("-I{}/include", sgx_library_path));
+
+    for f in URTS_FUNCTIONS {
+        builder = builder.allowlist_function(f);
+    }
 
     let out_path = mc_sgx_core_build::build_output_path();
-    bindings
+    builder
+        .generate()
+        .expect("Unable to generate bindings")
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }

--- a/urts/sys/src/lib.rs
+++ b/urts/sys/src/lib.rs
@@ -4,9 +4,9 @@
 #![feature(c_size_t)]
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-pub use core::ffi::c_size_t as size_t;
-pub use mc_sgx_core_sys_types::{sgx_status_t, sgx_target_info_t};
-pub use mc_sgx_urts_sys_types::{sgx_enclave_id_t, sgx_launch_token_t, sgx_misc_attribute_t};
+use core::ffi::c_size_t as size_t;
+use mc_sgx_core_sys_types::{sgx_status_t, sgx_target_info_t};
+use mc_sgx_urts_sys_types::{sgx_enclave_id_t, sgx_launch_token_t, sgx_misc_attribute_t};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 

--- a/urts/sys/types/Cargo.toml
+++ b/urts/sys/types/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 sw = []
 default = ["sw"]
 
+[dependencies]
+mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
+
 [dev-dependencies]
 test_enclave = { path = "../../../test_enclave" }
 

--- a/urts/sys/types/README.md
+++ b/urts/sys/types/README.md
@@ -1,3 +1,23 @@
-# Bindings to types from the untrusted SGX SDK
+# MobileCoin's FFI Bindings to the untrusted SGX types
 
-Provides the rust bindings to the SGX SDK untrusted C types.
+[![mc-sgx-urts-sys-types][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+Provides the rust type bindings to the `sgx_urts` library.
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-urts-sys-types.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/aead
+[license-image]: https://img.shields.io/crates/l/mc-sgx-urts-sys-types?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-urts-sys-types?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-urts-sys-types
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-urts-sys-types/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-urts-sys-types

--- a/urts/sys/types/build.rs
+++ b/urts/sys/types/build.rs
@@ -7,6 +7,7 @@ const URTS_TYPES: &[&str] = &[
     "sgx_enclave_id_t",
     "sgx_launch_token_t",
     "_sgx_misc_attribute_t",
+    "_sgx_kss_config_t",
 ];
 
 fn main() {

--- a/urts/sys/types/build.rs
+++ b/urts/sys/types/build.rs
@@ -1,37 +1,28 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 
-//! Builds the FFI bindings for the untrusted side of the Intel SGX SDK
-use bindgen::{callbacks::ParseCallbacks, Builder};
+//! Builds the FFI type bindings for the untrusted side of the Intel SGX SDK
 use std::{env, path::PathBuf};
 
-#[derive(Debug)]
-struct Callbacks;
-
-impl ParseCallbacks for Callbacks {
-    fn item_name(&self, name: &str) -> Option<String> {
-        match name {
-            "_attributes_t" => Some("sgx_attributes_t".to_owned()),
-            "_sgx_misc_attribute_t" => Some("sgx_misc_attribute_t".to_owned()),
-            _ => None,
-        }
-    }
-}
+const URTS_TYPES: &[&str] = &[
+    "sgx_enclave_id_t",
+    "sgx_launch_token_t",
+    "_sgx_misc_attribute_t",
+];
 
 fn main() {
     let sgx_library_path = mc_sgx_core_build::sgx_library_path();
-    let bindings = Builder::default()
+    let mut builder = mc_sgx_core_build::sgx_builder()
         .header_contents("urts_types.h", "#include <sgx_urts.h>")
-        .clang_arg(&format!("-I{}/include", sgx_library_path))
-        .blocklist_function("*")
-        .allowlist_type("sgx_enclave_id_t")
-        .allowlist_type("sgx_launch_token_t")
-        .allowlist_type("sgx_misc_attribute_t")
-        .parse_callbacks(Box::new(Callbacks))
-        .generate()
-        .expect("Unable to generate bindings");
+        .clang_arg(&format!("-I{}/include", sgx_library_path));
+
+    for t in URTS_TYPES {
+        builder = builder.allowlist_type(t);
+    }
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
+    builder
+        .generate()
+        .expect("Unable to generate bindings")
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }

--- a/urts/sys/types/src/lib.rs
+++ b/urts/sys/types/src/lib.rs
@@ -2,4 +2,5 @@
 //
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
+use mc_sgx_core_sys_types::{sgx_attributes_t, sgx_misc_select_t};
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/urts/sys/types/src/lib.rs
+++ b/urts/sys/types/src/lib.rs
@@ -2,5 +2,7 @@
 //
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-use mc_sgx_core_sys_types::{sgx_attributes_t, sgx_misc_select_t};
+use mc_sgx_core_sys_types::{
+    sgx_attributes_t, sgx_config_id_t, sgx_config_svn_t, sgx_misc_select_t,
+};
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
This also normalizes the urts crate to use the common SGX builder.rs
functionality.