### PR TITLE
Convert to `sim` feature for SGX crates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,4 +27,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
-      - run: cargo test --release --locked
+      - run: cargo test --release --locked --features sim

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -76,12 +76,12 @@ pub fn build_output_path() -> PathBuf {
 ///
 /// Some SGX libraries have a suffix for example `sgx_trts.a` versus
 /// `sgx_trts_sim.a`.  This will result the suffix based on the presence of the
-/// feature `hw`.
+/// feature `sim`.
 pub fn sgx_library_suffix() -> &'static str {
     // See https://doc.rust-lang.org/cargo/reference/features.html#build-scripts
     // for description of `CARGO_FEATURE_<name>`
-    match env::var("CARGO_FEATURE_HW") {
-        Ok(_) => "",
-        _ => "_sim",
+    match env::var("CARGO_FEATURE_SIM") {
+        Ok(_) => "_sim",
+        _ => "",
     }
 }

--- a/test_enclave/Cargo.toml
+++ b/test_enclave/Cargo.toml
@@ -8,8 +8,8 @@ mc-sgx-urts-sys-types = { path = "../urts/sys/types" }
 mc-sgx-core-sys-types = { path = "../core/sys/types" }
 
 [features]
-hw = []
 default = []
+sim = []
 
 [build-dependencies]
 cargo-emit = "0.2.1"

--- a/test_enclave/README.md
+++ b/test_enclave/README.md
@@ -3,8 +3,8 @@
 Provides a simple enclave that can be used to exercise the SGX SDK for creating
 an enclave and for calling into functions in the enclave.
 
-This crate supports testing with the simulation as well as the hardware SGX
-SDKs. In order to test with the hardware SDKs use the `hw` feature.
+This crate supports testing with the hardware as well as the simulation SGX
+SDKs. To test with the simulation SDKs use the `sim` feature.
 
 This crate can be added to the development dependency of the crate to test the
 creation of enclaves with.

--- a/trts/sys/Cargo.toml
+++ b/trts/sys/Cargo.toml
@@ -9,7 +9,7 @@ test = false
 
 [features]
 default = []
-hw = []
+sim = []
 
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../core/sys/types" }

--- a/trts/sys/README.md
+++ b/trts/sys/README.md
@@ -31,9 +31,8 @@ installed. When unset the location will default to `/opt/intel/sgxsdk`
 
 ## Features
 
-When no features are present the SGX software simulation libraries will be
-linked in. When the `hw` feature is present the hardware SGX libraries will be
-linked in.
+When no features are present the SGX hardware libraries will be linked in. When
+the `sim` feature is present the simulation SGX libraries will be linked in.
 
 ## References
 

--- a/urts/Cargo.toml
+++ b/urts/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-mc-sgx-urts-sys = { path = "sys", default-features = false }
+mc-sgx-urts-sys = { path = "sys" }
 mc-sgx-core-sys-types = { path = "../core/sys/types" }
 mc-sgx-urts-sys-types = { path = "sys/types" }
 
 [features]
-hw = ["mc-sgx-urts-sys/hw"]
+sim = ["mc-sgx-urts-sys/sim", "test_enclave/sim"]
 default = []
 
 [dev-dependencies]

--- a/urts/README.md
+++ b/urts/README.md
@@ -42,9 +42,8 @@ installed. When unset the location will default to `/opt/intel/sgxsdk`
 
 ## Features
 
-When no features are present the SGX software simulation libraries will be
-linked in. When the `hw` feature is present the hardware SGX libraries will be
-linked in.
+When no features are present the SGX hardware libraries will be linked in. When
+the `sim` feature is present the simulation SGX libraries will be linked in.
 
 ## References
 

--- a/urts/sys/Cargo.toml
+++ b/urts/sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-hw = []
+sim = []
 default = []
 
 [dependencies]

--- a/urts/sys/README.md
+++ b/urts/sys/README.md
@@ -40,9 +40,8 @@ installed. When unset the location will default to `/opt/intel/sgxsdk`
 
 ## Features
 
-When no features are present the SGX software simulation libraries will be
-linked in. When the `hw` feature is present the hardware SGX libraries will be
-linked in.
+When no features are present the SGX hardware libraries will be linked in. When
+the `sim` feature is present the simulation SGX libraries will be linked in.
 
 ## References
 


### PR DESCRIPTION
Previously the SGX crates defaulted to simulated builds and used a
feature, `hw` to do hardware builds.  Now hardware builds are the
default and users need to use the `sim` feature to do sim builds.  The
default to hardware builds was chosen as it is less likely someone
accidentally builds and runs simulation intending for hardware builds.