### PR TITLE
Make trts functions explicit

### DIFF
--- a/trts/sys/Cargo.toml
+++ b/trts/sys/Cargo.toml
@@ -2,6 +2,15 @@
 name = "mc-sgx-trts-sys"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+rust-version = "1.62.1"
+readme = "README.md"
+repository = "https://github.com/mobilecoinfoundation/sgx"
+authors = ["MobileCoin"]
+description = '''
+This crate contains the FFI linkage for the `sgx_trts` library.
+'''
+links = "sgx_trts"
 
 [lib]
 # test false due to needing an enclave to fully link

--- a/trts/sys/README.md
+++ b/trts/sys/README.md
@@ -1,6 +1,14 @@
-# FFI Bindings to the Trusted runtime system(tRTS) SGX functionality
+# MobileCoin's FFI Bindings to the Trusted runtime system(tRTS) SGX functionality
 
-Provides the rust bindings, and linking, to the SGX SDK tRTS C functions.
+[![mc-sgx-trts-sys][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+Provides the rust function bindngs to the `sgx_trts` library.
 
 ## Table of Contents
 
@@ -39,3 +47,15 @@ linked in.
 
 - <https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/docs/Intel_SGX_Enclave_Common_Loader_API_Reference.pdf>
 - <https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package>
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-trts-sys.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/aead
+[license-image]: https://img.shields.io/crates/l/mc-sgx-trts-sys?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-trts-sys?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-trts-sys
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-trts-sys/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-trts-sys

--- a/trts/sys/build.rs
+++ b/trts/sys/build.rs
@@ -5,7 +5,6 @@
 use cargo_emit::{rustc_link_lib, rustc_link_search};
 
 const TRTS_FUNCTIONS: &[&str] = &[
-    "sgx_accept_forward",
     "sgx_is_enclave_crashed",
     "sgx_is_outside_enclave",
     "sgx_is_within_enclave",

--- a/trts/sys/build.rs
+++ b/trts/sys/build.rs
@@ -2,27 +2,42 @@
 
 //! Builds the FFI function bindings for trts (trusted runtime system) of the
 //! Intel SGX SDK
-use bindgen::Builder;
 use cargo_emit::{rustc_link_lib, rustc_link_search};
+
+const TRTS_FUNCTIONS: &[&str] = &[
+    "sgx_accept_forward",
+    "sgx_is_enclave_crashed",
+    "sgx_is_outside_enclave",
+    "sgx_is_within_enclave",
+    "sgx_ocall",
+    "sgx_ocalloc",
+    "sgx_ocfree",
+    "sgx_rdpkru",
+    "sgx_read_rand",
+    "sgx_register_exception_handler",
+    "sgx_unregister_exception_handler",
+    "sgx_wrpkru",
+];
 
 fn main() {
     let sgx_library_path = mc_sgx_core_build::sgx_library_path();
     let sgx_suffix = mc_sgx_core_build::sgx_library_suffix();
-    rustc_link_lib!(&format!("sgx_trts{}", sgx_suffix));
+    rustc_link_lib!(&format!("static=sgx_trts{}", sgx_suffix));
     rustc_link_search!(&format!("{}/lib64", &sgx_library_path));
 
-    let bindings = Builder::default()
-        .header_contents("trts.h", "#include <sgx_trts.h>")
+    let mut builder = mc_sgx_core_build::sgx_builder()
+        .header("wrapper.h")
         .clang_arg(&format!("-I{}/include", &sgx_library_path))
-        .allowlist_recursively(false)
-        .blocklist_type("*")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .ctypes_prefix("core::ffi")
-        .generate()
-        .expect("Unable to generate bindings");
+        .blocklist_type("*");
+
+    for f in TRTS_FUNCTIONS {
+        builder = builder.allowlist_function(f);
+    }
 
     let out_path = mc_sgx_core_build::build_output_path();
-    bindings
+    builder
+        .generate()
+        .expect("Unable to generate bindings")
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 }

--- a/trts/sys/wrapper.h
+++ b/trts/sys/wrapper.h
@@ -1,0 +1,1 @@
+#include <sgx_trts.h>


### PR DESCRIPTION
This also normalizes the trts crate to use the common SGX builder.rs
functionality.