### PR TITLE
Add missing DCAP ql Cargo.toml keys

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
       - run: |
           cargo metadata --no-deps --format-version=1 | \
             jq -r '.packages[].name' | \
-            grep -v -e mc-sgx-core-build -e mc-sgx-dcap-quoteverify-sys -e mc-sgx-quote-verify -e mc-sgx-urts -e mc-sgx-capable-sys | \
+            grep -v -e mc-sgx-core-build -e mc-sgx-dcap-quoteverify-sys -e mc-sgx-dcap-ql-sys -e mc-sgx-quote-verify -e mc-sgx-urts -e mc-sgx-capable-sys | \
             xargs -n1 sh -c 'cargo nono check --package $0 || exit 255'
   markdown-lint:
     runs-on: [self-hosted, Linux, small]

--- a/dcap_ql/sys/Cargo.toml
+++ b/dcap_ql/sys/Cargo.toml
@@ -1,21 +1,20 @@
 [package]
 name = "mc-sgx-dcap-ql-sys"
 version = "0.1.0"
+authors = ["MobileCoin"]
+categories = ["external-ffi-bindings", "hardware-support"]
+description = "FFI linkage for the `sgx_dcap_ql` library."
 edition = "2021"
+keywords = ["ffi", "sgx"]
 license = "Apache-2.0"
-rust-version = "1.62.1"
+links = "sgx_dcap_ql"
 readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
-
-authors = ["MobileCoin"]
-description = '''
-This crate contains the FFI linkage for the `libsgx_dcap_ql.so` library.
-'''
-links = "sgx_dcap_ql"
+rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-dcap-ql-sys-types = { path = "types" }
-mc-sgx-core-sys-types = { path = "../../core/sys/types" }
+mc-sgx-dcap-ql-sys-types = { path = "types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap_ql/sys/src/lib.rs
+++ b/dcap_ql/sys/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! FFI functions for the SGX SDK DCAP ql library.
 
-#![no_std]
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 use mc_sgx_core_sys_types::{sgx_report_t, sgx_target_info_t};

--- a/dcap_ql/sys/types/Cargo.toml
+++ b/dcap_ql/sys/types/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "mc-sgx-dcap-ql-sys-types"
 version = "0.1.0"
+authors = ["MobileCoin"]
+categories = ["external-ffi-bindings", "hardware-support", "no-std"]
+description = "FFI type definitions for the `sgx_dcap_ql` library."
 edition = "2021"
+keywords = ["ffi", "sgx", "no-std"]
 license = "Apache-2.0"
-rust-version = "1.62.1"
 readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
-
-authors = ["MobileCoin"]
-description = '''
-This crate contains the FFI type definitions which are used by the `libsgx_dcap_ql.so` library.
-'''
+rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap_ql/sys/types/src/lib.rs
+++ b/dcap_ql/sys/types/src/lib.rs
@@ -2,8 +2,6 @@
 //! Rust FFI types for the SGX SDK DCAP ql library.
 
 #![no_std]
-// Nesting to work around clippy warnings, see
-// https://github.com/rust-lang/rust-bindgen/issues/1470
 #![allow(
     clippy::missing_safety_doc,
     non_camel_case_types,

--- a/tservice/sys/types/src/lib.rs
+++ b/tservice/sys/types/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![no_std]
 #![feature(c_size_t)]
-// Nesting to work around clippy warnings, see
-// https://github.com/rust-lang/rust-bindgen/issues/1470
 #![allow(
     clippy::missing_safety_doc,
     non_camel_case_types,
@@ -12,13 +10,10 @@
     non_upper_case_globals
 )]
 
-mod bindings {
-    use core::ffi::c_size_t as size_t;
-    use mc_sgx_core_sys_types::{
-        sgx_attributes_t, sgx_cpu_svn_t, sgx_isv_svn_t, sgx_key_request_t, sgx_measurement_t,
-        sgx_misc_select_t, sgx_prod_id_t, sgx_report_t, sgx_target_info_t,
-    };
-    use mc_sgx_tcrypto_sys_types::sgx_ec256_public_t;
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-}
-pub use bindings::*;
+use core::ffi::c_size_t as size_t;
+use mc_sgx_core_sys_types::{
+    sgx_attributes_t, sgx_cpu_svn_t, sgx_isv_svn_t, sgx_key_request_t, sgx_measurement_t,
+    sgx_misc_select_t, sgx_prod_id_t, sgx_report_t, sgx_target_info_t,
+};
+use mc_sgx_tcrypto_sys_types::sgx_ec256_public_t;
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Add missing manifest keys to the Cargo.toml(s) in the DCAP ql crates
to assist with publishing.

Also fixed some comments around clippy exclusions