### PR TITLE
Move common DCAP types to dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
  "mc-sgx-dcap-ql-sys-types",
+ "mc-sgx-dcap-sys-types",
 ]
 
 [[package]]
@@ -571,7 +572,6 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "mc-sgx-core-build",
- "mc-sgx-core-sys-types",
 ]
 
 [[package]]
@@ -581,8 +581,8 @@ dependencies = [
  "bindgen",
  "cargo-emit",
  "mc-sgx-core-build",
- "mc-sgx-dcap-ql-sys-types",
  "mc-sgx-dcap-quoteverify-sys-types",
+ "mc-sgx-dcap-sys-types",
 ]
 
 [[package]]
@@ -591,8 +591,16 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "mc-sgx-core-build",
+ "mc-sgx-dcap-sys-types",
+]
+
+[[package]]
+name = "mc-sgx-dcap-sys-types"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
- "mc-sgx-dcap-ql-sys-types",
 ]
 
 [[package]]
@@ -603,8 +611,8 @@ dependencies = [
  "cargo-emit",
  "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
- "mc-sgx-dcap-ql-sys-types",
  "mc-sgx-dcap-quoteverify-sys-types",
+ "mc-sgx-dcap-sys-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "capable/sys/types",
     "core/sys/types",
     "core/build",
+    "dcap/sys/types",
     "dcap_ql/sys",
     "dcap_ql/sys/types",
     "dcap_quoteverify/sys",

--- a/dcap/sys/types/Cargo.toml
+++ b/dcap/sys/types/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "mc-sgx-dcap-quoteverify-sys-types"
+name = "mc-sgx-dcap-sys-types"
 version = "0.1.0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
-description = "FFI type definitions used by the `sgx_dcap_quoteverify` library."
+description = "FFI type definitions for the SGX DCAP libraries."
 edition = "2021"
 keywords = ["ffi", "sgx", "no-std"]
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-dcap-sys-types = { path = "../../../dcap/sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"
-mc-sgx-core-build = { path = "../../../core/build" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }

--- a/dcap/sys/types/README.md
+++ b/dcap/sys/types/README.md
@@ -1,0 +1,24 @@
+# MobileCoin's Rust FFI for the Intel SGX SDK
+
+[![mc-sgx-dcap-sys-types][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+This crate contains the FFI type definitions which are used by the 
+SGX DCAP libraries.
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-dcap-sys-types.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/mc-sgx-dcap-sys-types
+[license-image]: https://img.shields.io/crates/l/mc-sgx-dcap-sys-types?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-dcap-sys-types?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-dcap-sys-types
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-dcap-sys-types/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-dcap-sys-types

--- a/dcap/sys/types/build.rs
+++ b/dcap/sys/types/build.rs
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Builds the FFI type bindings for the dcap libraries of the Intel
+//! SGX SDK
+
+const DCAP_TYPES: &[&str] = &[
+    "_quote3_error_t",
+    "_sgx_ql_qe3_id_t",
+    "_sgx_ql_config_t",
+    "_sgx_ql_config_version_t",
+    "_sgx_ql_pck_cert_id_t",
+    "_sgx_ql_qve_collateral_param_t",
+    "_sgx_ql_qve_collateral_t",
+    "_sgx_ql_log_level_t",
+    "_sgx_prod_type_t",
+    "sgx_ql_logging_callback_t",
+    "_sgx_pce_error_t",
+    "_sgx_ql_request_policy",
+    "_sgx_pce_info_t",
+    "_sgx_ql_att_key_id_param_t",
+    "_sgx_ql_att_id_list_t",
+    "_sgx_ql_qe_report_info_t",
+    "sgx_ql_attestation_algorithm_id_t",
+    "sgx_ql_cert_key_type_t",
+    "_sgx_ql_att_key_id_list_header_t",
+    "_sgx_ql_ppid_cleartext_cert_info_t",
+    "_sgx_ql_ppid_rsa2048_encrypted_cert_info_t",
+    "_sgx_ql_ppid_rsa3072_encrypted_cert_info_t",
+    "_sgx_ql_auth_data_t",
+    "_sgx_ql_certification_data_t",
+    "_sgx_ql_ecdsa_sig_data_t",
+    "_sgx_quote_header_t",
+    "_sgx_quote3_t",
+    "_sgx_ql_qv_result_t",
+    "_pck_cert_flag_enum_t",
+    "_sgx_ql_qv_supplemental_t",
+];
+
+fn main() {
+    let mut builder = mc_sgx_core_build::sgx_builder()
+        .header("wrapper.h")
+        .blocklist_function("*");
+
+    for t in DCAP_TYPES {
+        builder = builder.allowlist_type(t);
+    }
+
+    let out_path = mc_sgx_core_build::build_output_path();
+    builder
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/dcap/sys/types/src/lib.rs
+++ b/dcap/sys/types/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Rust FFI types for the SGX SDK DCAP libraries.
+
+#![no_std]
+#![allow(
+    clippy::missing_safety_doc,
+    non_camel_case_types,
+    non_snake_case,
+    non_upper_case_globals
+)]
+
+use mc_sgx_core_sys_types::{
+    sgx_att_key_id_ext_t, sgx_cpu_svn_t, sgx_isv_svn_t, sgx_key_128bit_t, sgx_quote_nonce_t,
+    sgx_report_body_t, sgx_report_t, sgx_target_info_t,
+};
+
+// time_t normally comes from libc, however libc doesn't have definitions for
+// the sgx target so we explicitly define it here.
+pub type time_t = i64;
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/dcap/sys/types/wrapper.h
+++ b/dcap/sys/types/wrapper.h
@@ -1,0 +1,5 @@
+#include <sgx_ql_quote.h>
+#include <sgx_ql_lib_common.h>
+#include <sgx_pce.h>
+#include <sgx_quote_3.h>
+#include <sgx_qve_header.h>

--- a/dcap_ql/sys/Cargo.toml
+++ b/dcap_ql/sys/Cargo.toml
@@ -13,10 +13,11 @@ repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-dcap-ql-sys-types = { path = "types", version = "=0.1.0" }
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
+mc-sgx-dcap-sys-types = { path = "../../dcap/sys/types", version = "=0.1.0" }
+mc-sgx-dcap-ql-sys-types = { path = "types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }

--- a/dcap_ql/sys/src/lib.rs
+++ b/dcap_ql/sys/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 use mc_sgx_core_sys_types::{sgx_report_t, sgx_target_info_t};
-use mc_sgx_dcap_ql_sys_types::{quote3_error_t, sgx_ql_path_type_t, sgx_ql_request_policy_t};
+use mc_sgx_dcap_ql_sys_types::sgx_ql_path_type_t;
+use mc_sgx_dcap_sys_types::{quote3_error_t, sgx_ql_request_policy_t};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/dcap_ql/sys/types/Cargo.toml
+++ b/dcap_ql/sys/types/Cargo.toml
@@ -11,9 +11,6 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
-[dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
-
 [build-dependencies]
 bindgen = "0.60.1"
-mc-sgx-core-build = { path = "../../../core/build" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }

--- a/dcap_ql/sys/types/build.rs
+++ b/dcap_ql/sys/types/build.rs
@@ -2,22 +2,10 @@
 //! Builds the FFI type bindings for the dcap quote library of the Intel SGX SDK
 
 const DCAP_QL_TYPES: &[&str] = &[
-    "_quote3_error_t",
-    "_sgx_pce_error_t",
-    "_sgx_pce_info_t",
-    "_sgx_prod_type_t",
-    "_sgx_ql_config_t",
-    "_sgx_ql_config_version_t",
-    "_sgx_ql_log_level_t",
-    "_sgx_ql_qe3_id_t",
+    "_sgx_ql_att_key_id_param_t",
+    "_sgx_ql_att_id_list_t",
     "_sgx_ql_qe_report_info_t",
-    "_sgx_ql_qve_collateral_param_t",
-    "_sgx_ql_qve_collateral_t",
-    "_sgx_ql_qve_collateral_t",
-    "_sgx_ql_request_policy",
-    "sgx_ql_logging_callback_t",
     "sgx_ql_path_type_t",
-    "sgx_quote3_error_t",
 ];
 
 fn main() {

--- a/dcap_ql/sys/types/src/lib.rs
+++ b/dcap_ql/sys/types/src/lib.rs
@@ -2,12 +2,6 @@
 //! Rust FFI types for the SGX SDK DCAP ql library.
 
 #![no_std]
-#![allow(
-    clippy::missing_safety_doc,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals
-)]
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-use mc_sgx_core_sys_types::{sgx_cpu_svn_t, sgx_isv_svn_t};
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/dcap_ql/sys/types/wrapper.h
+++ b/dcap_ql/sys/types/wrapper.h
@@ -1,3 +1,1 @@
 #include <sgx_dcap_ql_wrapper.h>
-#include <sgx_ql_lib_common.h>
-#include <sgx_pce.h>

--- a/dcap_quoteverify/sys/Cargo.toml
+++ b/dcap_quoteverify/sys/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.62.1"
 
 [dependencies]
 mc-sgx-dcap-quoteverify-sys-types = { path = "types", version = "=0.1.0" }
-mc-sgx-dcap-ql-sys-types = { path = "../../dcap_ql/sys/types", version = "=0.1.0" }
+mc-sgx-dcap-sys-types = { path = "../../dcap/sys/types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap_quoteverify/sys/src/lib.rs
+++ b/dcap_quoteverify/sys/src/lib.rs
@@ -3,8 +3,9 @@
 
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
-use mc_sgx_dcap_ql_sys_types::{quote3_error_t, sgx_ql_qve_collateral_t, sgx_ql_request_policy_t};
-use mc_sgx_dcap_quoteverify_sys_types::{
-    sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, sgx_qv_path_type_t, time_t,
+use mc_sgx_dcap_quoteverify_sys_types::sgx_qv_path_type_t;
+use mc_sgx_dcap_sys_types::{
+    quote3_error_t, sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, sgx_ql_qve_collateral_t,
+    sgx_ql_request_policy_t, time_t,
 };
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/dcap_quoteverify/sys/types/build.rs
+++ b/dcap_quoteverify/sys/types/build.rs
@@ -2,26 +2,7 @@
 //! Builds the FFI type bindings for the dcap quoteverify library of the Intel
 //! SGX SDK
 
-const DCAP_QUOTEVERIFY_TYPES: &[&str] = &[
-    "sgx_qv_path_type_t",
-    "_sgx_ql_qv_result_t",
-    "_sgx_ql_qv_supplemental_t",
-    "_pck_cert_flag_enum_t",
-    "_sgx_ql_att_key_id_param_t",
-    "_sgx_ql_att_id_list_t",
-    "_sgx_ql_qe_report_info_t",
-    "_sgx_ql_att_key_id_list_header_t",
-    "sgx_ql_attestation_algorithm_id_t",
-    "sgx_ql_cert_key_type_t",
-    "_sgx_ql_ppid_cleartext_cert_info_t",
-    "_sgx_ql_ppid_rsa2048_encrypted_cert_info_t",
-    "_sgx_ql_ppid_rsa3072_encrypted_cert_info_t",
-    "_sgx_ql_auth_data_t",
-    "_sgx_ql_certification_data_t",
-    "_sgx_ql_ecdsa_sig_data_t",
-    "_sgx_quote_header_t",
-    "_sgx_quote3_t",
-];
+const DCAP_QUOTEVERIFY_TYPES: &[&str] = &["sgx_qv_path_type_t"];
 
 fn main() {
     let mut builder = mc_sgx_core_build::sgx_builder()

--- a/dcap_quoteverify/sys/types/src/lib.rs
+++ b/dcap_quoteverify/sys/types/src/lib.rs
@@ -2,20 +2,6 @@
 //! Rust FFI types for the SGX SDK DCAP quoteverify library.
 
 #![no_std]
-#![allow(
-    clippy::missing_safety_doc,
-    non_camel_case_types,
-    non_snake_case,
-    non_upper_case_globals
-)]
+#![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
-use mc_sgx_core_sys_types::{
-    sgx_att_key_id_ext_t, sgx_cpu_svn_t, sgx_isv_svn_t, sgx_key_128bit_t, sgx_quote_nonce_t,
-    sgx_report_body_t, sgx_report_t, sgx_target_info_t,
-};
-use mc_sgx_dcap_ql_sys_types::sgx_pce_info_t;
-
-// time_t normally comes from libc, however libc doesn't have definitions for
-// the sgx target so we explicitly define it here.
-pub type time_t = i64;
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/dcap_quoteverify/sys/types/wrapper.h
+++ b/dcap_quoteverify/sys/types/wrapper.h
@@ -1,4 +1,1 @@
 #include <sgx_dcap_quoteverify.h>
-#include <sgx_qve_header.h>
-#include <sgx_ql_quote.h>
-#include <sgx_quote_3.h>

--- a/dcap_tvl/sys/Cargo.toml
+++ b/dcap_tvl/sys/Cargo.toml
@@ -18,7 +18,7 @@ test = false
 
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
-mc-sgx-dcap-ql-sys-types = { path = "../../dcap_ql/sys/types", version = "=0.1.0" }
+mc-sgx-dcap-sys-types = { path = "../../dcap/sys/types", version = "=0.1.0" }
 mc-sgx-dcap-quoteverify-sys-types = { path = "../../dcap_quoteverify/sys/types", version = "=0.1.0" }
 
 [build-dependencies]

--- a/dcap_tvl/sys/src/lib.rs
+++ b/dcap_tvl/sys/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
 
 use mc_sgx_core_sys_types::sgx_isv_svn_t;
-use mc_sgx_dcap_ql_sys_types::quote3_error_t;
-use mc_sgx_dcap_quoteverify_sys_types::{sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, time_t};
+use mc_sgx_dcap_sys_types::{quote3_error_t, sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, time_t};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
The `mc-sgx-dcap-sys-types` crate as been created to house common dcap
types used between all the DCAP FFI crates.