### PR TITLE
Remove use of test enclave in `mc-sgx-urts-sys-*` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "log"
@@ -712,7 +712,6 @@ dependencies = [
  "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
  "mc-sgx-urts-sys-types",
- "test_enclave",
 ]
 
 [[package]]
@@ -723,7 +722,6 @@ dependencies = [
  "cargo-emit",
  "mc-sgx-core-build",
  "mc-sgx-core-sys-types",
- "test_enclave",
 ]
 
 [[package]]

--- a/urts/sys/Cargo.toml
+++ b/urts/sys/Cargo.toml
@@ -24,6 +24,3 @@ mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
 mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
-
-[dev-dependencies]
-test_enclave = { path = "../../test_enclave", version = "=0.1.0" }

--- a/urts/sys/src/lib.rs
+++ b/urts/sys/src/lib.rs
@@ -9,35 +9,3 @@ use mc_sgx_core_sys_types::{sgx_status_t, sgx_target_info_t};
 use mc_sgx_urts_sys_types::{sgx_enclave_id_t, sgx_launch_token_t, sgx_misc_attribute_t};
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::{os::raw::c_int, ptr};
-    use test_enclave::{ecall_add_2, ENCLAVE};
-
-    #[test]
-    fn bindings_can_be_used_to_call_enclave_functions() {
-        let mut enclave_id: sgx_enclave_id_t = 0;
-        let mut bytes = ENCLAVE.to_vec();
-        let result = unsafe {
-            sgx_create_enclave_from_buffer_ex(
-                bytes.as_mut_ptr(),
-                bytes.len().try_into().unwrap(),
-                0,
-                &mut enclave_id,
-                ptr::null_mut(),
-                0,
-                ptr::null_mut(),
-            )
-        };
-        assert_eq!(result, sgx_status_t::SGX_SUCCESS);
-
-        let mut sum: c_int = 0;
-        let result = unsafe { ecall_add_2(enclave_id, 10, &mut sum) };
-        let destroy_result = unsafe { sgx_destroy_enclave(enclave_id) };
-        assert_eq!(result, sgx_status_t::SGX_SUCCESS);
-        assert_eq!(destroy_result, sgx_status_t::SGX_SUCCESS);
-        assert_eq!(sum, 10 + 2);
-    }
-}

--- a/urts/sys/types/Cargo.toml
+++ b/urts/sys/types/Cargo.toml
@@ -11,15 +11,8 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
-[features]
-sw = []
-default = ["sw"]
-
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
-
-[dev-dependencies]
-test_enclave = { path = "../../../test_enclave" }
 
 [build-dependencies]
 bindgen = "0.60.1"


### PR DESCRIPTION
Removing the test enclave dependency to remove the need to publish the
test enclave with the crate.