### PR TITLE
Fix readme crate links

### DIFF
--- a/capable/sys/README.md
+++ b/capable/sys/README.md
@@ -10,10 +10,8 @@
 
 This crate contains the FFI linkage for the `libsgx_capable.so` library.
 
-[//]: # (badges)
-
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-capable-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-capable-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-capable-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/capable/sys/types/README.md
+++ b/capable/sys/types/README.md
@@ -8,12 +8,11 @@
 [![CodeCov Status][codecov-image]][codecov-link]
 [![dependency status][deps-image]][deps-link]
 
-This crate contains the FFI type definitions which are used by the `sgx_capable` library.
-
-[//]: # (badges)
+This crate contains the FFI type definitions which are used by the `sgx_capable`
+library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-capable-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-capable-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-capable-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/core/sys/types/README.md
+++ b/core/sys/types/README.md
@@ -1,0 +1,23 @@
+# MobileCoin's FFI Bindings to the core SGX types
+
+[![mc-sgx-core-sys-types][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+Provides the rust type bindings to the core SGX types.
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-core-sys-types.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/mc-sgx-core-sys-types
+[license-image]: https://img.shields.io/crates/l/mc-sgx-core-sys-types?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-core-sys-types?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-core-sys-types
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-core-sys-types/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-core-sys-types

--- a/dcap_ql/sys/README.md
+++ b/dcap_ql/sys/README.md
@@ -11,7 +11,7 @@
 This crate contains the FFI linkage for the `libsgx_dcap_ql.so` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-dcap-ql-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-dcap-ql-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-dcap-ql-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/dcap_ql/sys/types/README.md
+++ b/dcap_ql/sys/types/README.md
@@ -8,11 +8,11 @@
 [![CodeCov Status][codecov-image]][codecov-link]
 [![dependency status][deps-image]][deps-link]
 
-This crate contains the FFI type definitions which are used by the 
+This crate contains the FFI type definitions which are used by the
 `libsgx_dcap_ql` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-dcap-ql-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-dcap-ql-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-dcap-ql-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/dcap_quoteverify/sys/README.md
+++ b/dcap_quoteverify/sys/README.md
@@ -12,7 +12,7 @@ This crate contains the FFI linkage for the `libsgx_dcap_quoteverify.so`
 library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-dcap-quoteverify-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-dcap-quoteverify-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-dcap-quoteverify-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/dcap_quoteverify/sys/types/README.md
+++ b/dcap_quoteverify/sys/types/README.md
@@ -8,11 +8,11 @@
 [![CodeCov Status][codecov-image]][codecov-link]
 [![dependency status][deps-image]][deps-link]
 
-This crate contains the FFI type definitions which are used by the 
+This crate contains the FFI type definitions which are used by the
 `libsgx_dcap_quoteverify` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-dcap-quoteverify-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-dcap-quoteverify-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-dcap-quoteverify-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tcrypto/sys/README.md
+++ b/tcrypto/sys/README.md
@@ -11,7 +11,7 @@
 This crate contains the FFI linkage for the `libsgx_tcrypto.a` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tcrypto-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tcrypto-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tcrypto-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tcrypto/sys/types/README.md
+++ b/tcrypto/sys/types/README.md
@@ -12,7 +12,7 @@ This crate contains the FFI type definitions which are used by the
 `libsgx_tcrypto.a` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tcrypto-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tcrypto-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tcrypto-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/trts/sys/README.md
+++ b/trts/sys/README.md
@@ -48,7 +48,7 @@ the `sim` feature is present the simulation SGX libraries will be linked in.
 - <https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package>
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-trts-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-trts-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-trts-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tservice/sys/README.md
+++ b/tservice/sys/README.md
@@ -11,7 +11,7 @@
 This crate contains the FFI linkage for the `libsgx_tservice.a` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tservice-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tservice-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tservice-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tservice/sys/types/README.md
+++ b/tservice/sys/types/README.md
@@ -12,7 +12,7 @@ This crate contains the FFI type definitions which are used by the
 `libsgx_tservice.a` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tservice-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tservice-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tservice-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tstdc/sys/README.md
+++ b/tstdc/sys/README.md
@@ -11,7 +11,7 @@
 This crate contains the FFI linkage for the `libsgx_tstdc.a` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tstdc-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tstdc-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tstdc-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/tstdc/sys/types/README.md
+++ b/tstdc/sys/types/README.md
@@ -12,7 +12,7 @@ This crate contains the FFI type definitions which are used by the `sgx_tstdc`
 library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-tstdc-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-tstdc-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-tstdc-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/urts/sys/README.md
+++ b/urts/sys/README.md
@@ -49,7 +49,7 @@ the `sim` feature is present the simulation SGX libraries will be linked in.
 - <https://github.com/intel/linux-sgx#build-the-intelr-sgx-sdk-and-intelr-sgx-psw-package>
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-urts-sys.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-urts-sys
 [license-image]: https://img.shields.io/crates/l/mc-sgx-urts-sys?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat

--- a/urts/sys/types/README.md
+++ b/urts/sys/types/README.md
@@ -11,7 +11,7 @@
 Provides the rust type bindings to the `sgx_urts` library.
 
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-urts-sys-types.svg?style=for-the-badge
-[crate-link]: https://crates.io/crates/aead
+[crate-link]: https://crates.io/crates/mc-sgx-urts-sys-types
 [license-image]: https://img.shields.io/crates/l/mc-sgx-urts-sys-types?style=for-the-badge
 [chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
 [chat-link]: https://mobilecoin.chat


### PR DESCRIPTION
Previously many readmes linked to the aead crate on crates.io instead of
the correct crate.  These links have been corrected now.

Also filled out readme for the `mc-sgx-core-sys-types` crate.