### PR TITLE
Add `mc-sgx-core-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-core-types"
+version = "0.1.0"
+dependencies = [
+ "mc-sgx-core-sys-types",
+]
+
+[[package]]
 name = "mc-sgx-dcap-ql-sys"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ resolver = "2"
 members = [
     "capable/sys",
     "capable/sys/types",
-    "core/sys/types",
     "core/build",
+    "core/sys/types",
+    "core/types",
     "dcap/sys/types",
     "dcap_ql/sys",
     "dcap_ql/sys/types",

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mc-sgx-core-types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.1.0" }

--- a/core/types/README.md
+++ b/core/types/README.md
@@ -1,0 +1,23 @@
+# MobileCoin's core SGX types
+
+[![mc-sgx-core-types][crate-image]][crate-link]
+![License][license-image]
+[![Project Chat][chat-image]][chat-link]
+
+[![Docs Status][docs-image]][docs-link]
+[![CodeCov Status][codecov-image]][codecov-link]
+[![dependency status][deps-image]][deps-link]
+
+Provides the rust wrappers for the core SGX types.
+
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-core-types.svg?style=for-the-badge
+[crate-link]: https://crates.io/crates/mc-sgx-core-types
+[license-image]: https://img.shields.io/crates/l/mc-sgx-core-types?style=for-the-badge
+[chat-image]: https://img.shields.io/discord/MOBILECOIN?style=for-the-badge
+[chat-link]: https://mobilecoin.chat
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-core-types?style=for-the-badge
+[docs-link]: https://docs.rs/crate/mc-sgx-core-types
+[codecov-image]: https://img.shields.io/codecov/c/github/mobilecoinfoundation/sgx/develop?style=for-the-badge
+[codecov-link]: https://codecov.io/gh/mobilecoinfoundation/sgx
+[deps-image]: https://deps.rs/crate/mc-sgx-core-types/status.svg?style=for-the-badge
+[deps-link]: https://deps.rs/crate/mc-sgx-core-types

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Rust wrappers for SGX types
+
+#![no_std]


### PR DESCRIPTION
Add the initial `mc-sgx-core-types` crate.  It is currently empty and
with the intent to add the desired wrappers in follow on commits

Fixes #78 