### PR TITLE
Use github runners for ci

### DIFF
--- a/.github/actions/dcap-libs/action.yaml
+++ b/.github/actions/dcap-libs/action.yaml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run:
         source /etc/lsb-release &&
-        echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $DISTRIB_CODENAME main" | tee /etc/apt/sources.list.d/intel-sgx.list &&
-        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - &&
-        apt-get update &&
-        apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev
+        echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list &&
+        wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add - &&
+        sudo apt-get update &&
+        sudo apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev

--- a/.github/actions/sgxsdk/action.yaml
+++ b/.github/actions/sgxsdk/action.yaml
@@ -1,0 +1,25 @@
+name: Install SGX SDK
+description: Installs the Intel SGX SDK (and propagates environment variables)
+
+runs:
+  using: composite
+  steps:
+    - name: Install SGX SDK
+      shell: bash
+      # In order to propagate teh environment variables to subsequent steps we
+      # need to redirect through $GITHUB_ENV, see
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+      # We can't do `cat /opt/intel/sgxsdk/environment >> $GITHUB_ENV` because
+      # the environment file has _logic_ which the `GITHUB_ENV` parser will
+      # fail on.  So we manually pass on the known environment variables.
+      run:
+        source /etc/lsb-release &&
+        wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${DISTRIB_RELEASE}-server/sgx_linux_x64_sdk_2.17.100.3.bin" &&
+        chmod +x ./sgx_linux_x64_sdk_2.17.100.3.bin &&
+        ./sgx_linux_x64_sdk_2.17.100.3.bin --prefix=/opt/intel &&
+        source /opt/intel/sgxsdk/environment &&
+        echo "SGX_SDK=$SGX_SDK" >> $GITHUB_ENV &&
+        echo "PATH=$PATH" >> $GITHUB_ENV &&
+        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV &&
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - 'main'
-      - 'develop'
       - 'feature/**'
 
 env:
@@ -13,28 +12,26 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
+      - uses: ./.github/actions/sgxsdk
       - uses: ./.github/actions/dcap-libs
       - run: cargo build --release --locked
   test:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
-    env:
-      LD_LIBRARY_PATH: "/opt/intel/sgxsdk/lib64"
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
+      - uses: ./.github/actions/sgxsdk
       - uses: ./.github/actions/dcap-libs
-      - run: cargo test --release --locked --features sim
+      - run:
+          cargo test --release --locked --features sim
   doc:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,11 +1,8 @@
 name: Lint
 on:
   pull_request:
-    paths-ignore:
-      - README.md
     branches:
       - 'main'
-      - 'develop'
       - 'feature/**'
 
 env:
@@ -14,16 +11,14 @@ env:
 
 jobs:
   rustfmt:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
         run: rustup show
       - run: cargo fmt --all -- --check
   clippy:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
@@ -31,8 +26,7 @@ jobs:
       - uses: ./.github/actions/dcap-libs
       - run: cargo clippy --all --all-features --locked -- -D warnings
   nono:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/rust-sgx-base:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rust toolchain
@@ -46,8 +40,7 @@ jobs:
             grep -v -e mc-sgx-core-build -e mc-sgx-dcap-quoteverify-sys -e mc-sgx-dcap-ql-sys -e mc-sgx-quote-verify -e mc-sgx-urts -e mc-sgx-capable-sys | \
             xargs -n1 sh -c 'cargo nono check --package $0 || exit 255'
   markdown-lint:
-    runs-on: [self-hosted, Linux, small]
-    container: mobilecoin/builder-install:latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: xt0rted/markdownlint-problem-matcher@v1


### PR DESCRIPTION
Previously the self hosted machines were used. There is no need to
utilize the SGX hardware for the current CI steps so these have moved
over to github runners to free up the self hosted images