### PR TITLE
Update the bindgen derive logic

### DIFF
--- a/capable/sys/types/build.rs
+++ b/capable/sys/types/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(["sgx_device_status_t"].iter());
+    let callback = SgxParseCallbacks::default().enum_types(["sgx_device_status_t"].iter());
 
     mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -18,7 +18,7 @@ static DEFAULT_SGX_SDK_PATH: &str = "/opt/intel/sgxsdk";
 /// ```C
 /// void some_function(foo_bar arg);
 /// ```
-const STRIP_UNDERSCORE_PREFIX: &[&str] = &["_sgx", "_tee", "_quote3", "_pck"];
+const STRIP_UNDERSCORE_PREFIX: &[&str] = &["_sgx", "_tee", "_quote3", "_pck", "_rsa"];
 
 /// Normalizes a type encountered by bindgen
 ///
@@ -57,13 +57,7 @@ pub fn normalize_item_name(name: &str) -> Option<String> {
 pub fn sgx_builder() -> Builder {
     Builder::default()
         .derive_copy(false)
-        .derive_debug(true)
-        .derive_default(true)
-        .derive_eq(true)
-        .derive_hash(true)
-        .derive_ord(true)
-        .derive_partialeq(true)
-        .derive_partialord(true)
+        .derive_debug(false)
         // TODO: Comments can cause doc tests to fail, see https://github.com/rust-lang/rust-bindgen/issues/1313
         //       Disable doctest in the relevant crates: https://github.com/rust-lang/cargo/issues/7252#issuecomment-521778066
         .generate_comments(false)
@@ -80,30 +74,68 @@ pub fn sgx_builder() -> Builder {
 /// This provides a default implementation for most of the SGX libraries
 #[derive(Debug, Default)]
 pub struct SgxParseCallbacks {
-    // types that are blocklisted from deriving Clone for.
+    // types that are copyable and thus should derive `Copy`
     //
-    // These may either already have the Clone attribute from bindgen, or they
-    // can't derive clone due to having non cloneable default types like
-    // `__IncompleteArrayField`.
-    blocklisted_clone_types: Vec<String>,
+    // These are usually small types or packed types
+    copyable_types: Vec<String>,
+
+    // types that are enums
+    enum_types: Vec<String>,
+
+    // Dynamically Sized types
+    dynamically_sized_types: Vec<String>,
 }
 
 impl SgxParseCallbacks {
     /// SGXParseCallbacks to be used with [bindgen::Builder::parse_callbacks]
     ///
     /// # Arguments
-    /// * `blocklisted_clone_types` - Types to blocklist from deriving `Clone`.
-    pub fn new<'a, E, I>(blocklisted_clone_types: I) -> Self
+    /// * `enum_types` - Types that are enums.  Bindgen derives some attributes
+    ///   by default for enums, in order to properly handle them they must be
+    ///   known.
+    ///
+    ///     Note: Enums will also derive `Copy`, there is no need to specify in
+    ///     [derive_copy]
+    pub fn new<'a, E, I>(enum_types: I) -> Self
     where
         I: Iterator<Item = &'a E>,
         E: ToString + 'a + ?Sized,
     {
-        let blocklisted_clone_types = blocklisted_clone_types
-            .map(ToString::to_string)
-            .collect::<Vec<_>>();
+        let enum_types = enum_types.map(ToString::to_string).collect::<Vec<_>>();
         Self {
-            blocklisted_clone_types,
+            copyable_types: enum_types.clone(),
+            enum_types,
+            dynamically_sized_types: vec![],
         }
+    }
+
+    /// Types to derive copy for, usually packed types
+    ///
+    /// # Arguments
+    /// * `copyable_types` - Types to derive copy for.
+    pub fn derive_copy<'a, E, I>(mut self, copyable_types: I) -> Self
+    where
+        I: Iterator<Item = &'a E>,
+        E: ToString + 'a + ?Sized,
+    {
+        self.copyable_types
+            .extend(copyable_types.map(ToString::to_string));
+        self
+    }
+
+    /// Dynamically Sized Types
+    ///
+    /// # Arguments
+    /// * `dynamically_sized_types` - Types that are dynamically sized.  Due to
+    ///   the dynamic size certain traits like `Eq` can't be derived.
+    pub fn dynamically_sized_types<'a, E, I>(mut self, dynamically_sized_types: I) -> Self
+    where
+        I: Iterator<Item = &'a E>,
+        E: ToString + 'a + ?Sized,
+    {
+        self.dynamically_sized_types
+            .extend(dynamically_sized_types.map(ToString::to_string));
+        self
     }
 }
 
@@ -113,11 +145,23 @@ impl ParseCallbacks for SgxParseCallbacks {
     }
 
     fn add_derives(&self, name: &str) -> Vec<String> {
-        if self.blocklisted_clone_types.iter().any(|n| *n == name) {
-            vec![]
-        } else {
-            vec!["Clone".to_string()]
+        if self.dynamically_sized_types.iter().any(|n| *n == name) {
+            // For dynamically sized types we don't even derive Debug, because
+            // they are often times packed and packed types can't derive Debug
+            // without deriving Copy, however by the dynamic nature one can't
+            // derive Copy
+            return vec![];
         }
+        let mut attributes = vec!["Debug"];
+        if !self.enum_types.iter().any(|n| *n == name) {
+            attributes.extend(["Clone", "Hash", "PartialEq", "Eq"]);
+        }
+
+        // The [new] method added enums to the [copyable_types]
+        if self.copyable_types.iter().any(|n| *n == name) {
+            attributes.push("Copy");
+        }
+        attributes.into_iter().map(String::from).collect::<Vec<_>>()
     }
 }
 

--- a/core/sys/types/build.rs
+++ b/core/sys/types/build.rs
@@ -52,18 +52,26 @@ const CORE_TYPES: &[&str] = &[
 
 fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
-    let callback = SgxParseCallbacks::new(
-        [
-            "sgx_status_t",
-            "sgx_quote_t",
-            "sgx_quote_sign_type_t",
-            "sgx_update_info_bit_t",
-            "sgx_ql_att_key_id_t",
-            "sgx_att_key_id_ext_t",
-            "sgx_qe_report_info_t",
-        ]
-        .iter(),
-    );
+    let callback = SgxParseCallbacks::new(["sgx_status_t", "sgx_quote_sign_type_t"].iter())
+        .derive_copy(
+            [
+                "sgx_update_info_bit_t",
+                "sgx_ql_att_key_id_t",
+                "sgx_att_key_id_ext_t",
+                "sgx_qe_report_info_t",
+                "sgx_quote_nonce_t",
+                "sgx_target_info_t",
+                "sgx_report_t",
+                "sgx_report_body_t",
+                "sgx_key_id_t",
+                "sgx_cpu_svn_t",
+                "sgx_measurement_t",
+                "sgx_report_data_t",
+                "sgx_attributes_t",
+            ]
+            .iter(),
+        )
+        .dynamically_sized_types(["sgx_quote_t"].iter());
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .clang_arg(&format!("-I{}", include_path))

--- a/core/sys/types/build.rs
+++ b/core/sys/types/build.rs
@@ -52,7 +52,8 @@ const CORE_TYPES: &[&str] = &[
 
 fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
-    let callback = SgxParseCallbacks::new(["sgx_status_t", "sgx_quote_sign_type_t"].iter())
+    let callback = SgxParseCallbacks::default()
+        .enum_types(["sgx_status_t", "sgx_quote_sign_type_t"].iter())
         .derive_copy(
             [
                 "sgx_update_info_bit_t",

--- a/dcap/ql/sys/types/build.rs
+++ b/dcap/ql/sys/types/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(["sgx_ql_path_type_t"].iter());
+    let callback = SgxParseCallbacks::default().enum_types(["sgx_ql_path_type_t"].iter());
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .clang_arg(&format!("-I{}", include_path))

--- a/dcap/quoteverify/sys/types/build.rs
+++ b/dcap/quoteverify/sys/types/build.rs
@@ -10,7 +10,7 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(["sgx_qv_path_type_t"].iter());
+    let callback = SgxParseCallbacks::default().enum_types(["sgx_qv_path_type_t"].iter());
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .clang_arg(&format!("-I{}", include_path))

--- a/dcap/sys/types/build.rs
+++ b/dcap/sys/types/build.rs
@@ -38,47 +38,48 @@ const DCAP_TYPES: &[&str] = &[
 ];
 
 fn main() {
-    let callback = SgxParseCallbacks::new(
-        [
-            "quote3_error_t",
-            "sgx_ql_config_version_t",
-            "sgx_ql_log_level_t",
-            "sgx_prod_type_t",
-            "sgx_pce_error_t",
-            "sgx_ql_request_policy_t",
-            "sgx_ql_attestation_algorithm_id_t",
-            "sgx_ql_cert_key_type_t",
-            "sgx_ql_qv_result_t",
-            "pck_cert_flag_enum_t",
-        ]
-        .iter(),
-    )
-    .derive_copy(
-        [
-            "quote3_error_t",
-            "sgx_ql_pck_cert_id_t",
-            "sgx_ql_config_t",
-            "sgx_pce_info_t",
-            "sgx_ql_att_key_id_list_header_t",
-            "sgx_quote_header_t",
-            "sgx_ql_qe_report_info_t",
-            "sgx_ql_ppid_cleartext_cert_info_t",
-            "sgx_ql_ppid_rsa2048_encrypted_cert_info_t",
-            "sgx_ql_ppid_rsa3072_encrypted_cert_info_t",
-        ]
-        .iter(),
-    )
-    .dynamically_sized_types(
-        [
-            "sgx_ql_auth_data_t",
-            "sgx_ql_certification_data_t",
-            "sgx_ql_ecdsa_sig_data_t",
-            "sgx_quote3_t",
-            "sgx_ql_att_key_id_param_t",
-            "sgx_ql_att_id_list_t",
-        ]
-        .iter(),
-    );
+    let callback = SgxParseCallbacks::default()
+        .enum_types(
+            [
+                "quote3_error_t",
+                "sgx_ql_config_version_t",
+                "sgx_ql_log_level_t",
+                "sgx_prod_type_t",
+                "sgx_pce_error_t",
+                "sgx_ql_request_policy_t",
+                "sgx_ql_attestation_algorithm_id_t",
+                "sgx_ql_cert_key_type_t",
+                "sgx_ql_qv_result_t",
+                "pck_cert_flag_enum_t",
+            ]
+            .iter(),
+        )
+        .derive_copy(
+            [
+                "quote3_error_t",
+                "sgx_ql_pck_cert_id_t",
+                "sgx_ql_config_t",
+                "sgx_pce_info_t",
+                "sgx_ql_att_key_id_list_header_t",
+                "sgx_quote_header_t",
+                "sgx_ql_qe_report_info_t",
+                "sgx_ql_ppid_cleartext_cert_info_t",
+                "sgx_ql_ppid_rsa2048_encrypted_cert_info_t",
+                "sgx_ql_ppid_rsa3072_encrypted_cert_info_t",
+            ]
+            .iter(),
+        )
+        .dynamically_sized_types(
+            [
+                "sgx_ql_auth_data_t",
+                "sgx_ql_certification_data_t",
+                "sgx_ql_ecdsa_sig_data_t",
+                "sgx_quote3_t",
+                "sgx_ql_att_key_id_param_t",
+                "sgx_ql_att_id_list_t",
+            ]
+            .iter(),
+        );
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .parse_callbacks(Box::new(callback))

--- a/dcap/sys/types/build.rs
+++ b/dcap/sys/types/build.rs
@@ -40,12 +40,6 @@ const DCAP_TYPES: &[&str] = &[
 fn main() {
     let callback = SgxParseCallbacks::new(
         [
-            "sgx_ql_auth_data_t",
-            "sgx_quote3_t",
-            "sgx_ql_att_id_list_t",
-            "sgx_ql_att_key_id_param_t",
-            "sgx_ql_ecdsa_sig_data_t",
-            "sgx_ql_certification_data_t",
             "quote3_error_t",
             "sgx_ql_config_version_t",
             "sgx_ql_log_level_t",
@@ -56,6 +50,12 @@ fn main() {
             "sgx_ql_cert_key_type_t",
             "sgx_ql_qv_result_t",
             "pck_cert_flag_enum_t",
+        ]
+        .iter(),
+    )
+    .derive_copy(
+        [
+            "quote3_error_t",
             "sgx_ql_pck_cert_id_t",
             "sgx_ql_config_t",
             "sgx_pce_info_t",
@@ -65,6 +65,17 @@ fn main() {
             "sgx_ql_ppid_cleartext_cert_info_t",
             "sgx_ql_ppid_rsa2048_encrypted_cert_info_t",
             "sgx_ql_ppid_rsa3072_encrypted_cert_info_t",
+        ]
+        .iter(),
+    )
+    .dynamically_sized_types(
+        [
+            "sgx_ql_auth_data_t",
+            "sgx_ql_certification_data_t",
+            "sgx_ql_ecdsa_sig_data_t",
+            "sgx_quote3_t",
+            "sgx_ql_att_key_id_param_t",
+            "sgx_ql_att_id_list_t",
         ]
         .iter(),
     );

--- a/tcrypto/sys/types/build.rs
+++ b/tcrypto/sys/types/build.rs
@@ -35,15 +35,16 @@ const CRYPTO_TYPES: &[&str] = &[
 ];
 
 fn main() {
-    let callback = SgxParseCallbacks::new(
-        [
-            "sgx_rsa_result_t",
-            "sgx_rsa_key_type_t",
-            "sgx_generic_ecresult_t",
-        ]
-        .iter(),
-    )
-    .derive_copy(["sgx_ec256_public_t", "rsa_params_t"].iter());
+    let callback = SgxParseCallbacks::default()
+        .enum_types(
+            [
+                "sgx_rsa_result_t",
+                "sgx_rsa_key_type_t",
+                "sgx_generic_ecresult_t",
+            ]
+            .iter(),
+        )
+        .derive_copy(["sgx_ec256_public_t", "rsa_params_t"].iter());
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 

--- a/tcrypto/sys/types/build.rs
+++ b/tcrypto/sys/types/build.rs
@@ -37,13 +37,13 @@ const CRYPTO_TYPES: &[&str] = &[
 fn main() {
     let callback = SgxParseCallbacks::new(
         [
-            "sgx_generic_ecresult_t",
             "sgx_rsa_result_t",
-            "sgx_rsa_params_t",
             "sgx_rsa_key_type_t",
+            "sgx_generic_ecresult_t",
         ]
         .iter(),
-    );
+    )
+    .derive_copy(["sgx_ec256_public_t", "rsa_params_t"].iter());
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 

--- a/tservice/sys/types/build.rs
+++ b/tservice/sys/types/build.rs
@@ -29,7 +29,8 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(["sgx_dh_session_role_t"].iter())
+    let callback = SgxParseCallbacks::default()
+        .enum_types(["sgx_dh_session_role_t"].iter())
         .derive_copy(
             [
                 "sgx_dh_msg1_t",

--- a/tservice/sys/types/build.rs
+++ b/tservice/sys/types/build.rs
@@ -29,20 +29,25 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(
-        [
-            "sgx_dh_msg1_t",
-            "sgx_dh_msg2_t",
-            "sgx_dh_msg3_t",
-            "sgx_sealed_data_t",
-            "sgx_dh_msg3_body_t",
-            "sgx_aes_gcm_data_t",
-            "sgx_dh_session_role_t",
-            "sgx_dh_session_enclave_identity_t",
-            "tee_attributes_t",
-        ]
-        .iter(),
-    );
+    let callback = SgxParseCallbacks::new(["sgx_dh_session_role_t"].iter())
+        .derive_copy(
+            [
+                "sgx_dh_msg1_t",
+                "sgx_dh_msg2_t",
+                "sgx_dh_session_enclave_identity_t",
+                "tee_attributes_t",
+            ]
+            .iter(),
+        )
+        .dynamically_sized_types(
+            [
+                "sgx_dh_msg3_body_t",
+                "sgx_aes_gcm_data_t",
+                "sgx_dh_msg3_t",
+                "sgx_sealed_data_t",
+            ]
+            .iter(),
+        );
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .clang_arg(&format!("-I{}", include_path))

--- a/urts/sys/types/build.rs
+++ b/urts/sys/types/build.rs
@@ -14,7 +14,7 @@ fn main() {
     let include_path = mc_sgx_core_build::sgx_include_string();
     cargo_emit::rerun_if_changed!(include_path);
 
-    let callback = SgxParseCallbacks::new(["sgx_kss_config_t"].iter());
+    let callback = SgxParseCallbacks::default().derive_copy(["sgx_kss_config_t"].iter());
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
         .clang_arg(&format!("-I{}", include_path))


### PR DESCRIPTION
Previously many generated types were missing common derive traits like
"Clone", "Debug", etc.  Now most types default to having those traits.
There is a separate list for:
- Types that are enums
- Types that should implement the "Copy" trait.
- Types that are dynamically sized (These implement no traits)