### PR TITLE
Enable docs generation for bindgen crates

### DIFF
--- a/capable/sys/Cargo.toml
+++ b/capable/sys/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-capable-sys-types = { path = "types", version = "=0.1.0" }
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }

--- a/capable/sys/types/Cargo.toml
+++ b/capable/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -64,9 +64,6 @@ pub fn sgx_builder() -> Builder {
         .derive_ord(true)
         .derive_partialeq(true)
         .derive_partialord(true)
-        // TODO: Comments can cause doc tests to fail, see https://github.com/rust-lang/rust-bindgen/issues/1313
-        //       Disable doctest in the relevant crates: https://github.com/rust-lang/cargo/issues/7252#issuecomment-521778066
-        .generate_comments(false)
         .default_enum_style(EnumVariation::NewType { is_bitfield: false })
         .prepend_enum_name(false)
         .use_core()

--- a/core/sys/types/Cargo.toml
+++ b/core/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/dcap/ql/sys/Cargo.toml
+++ b/dcap/ql/sys/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.1.0" }

--- a/dcap/ql/sys/types/Cargo.toml
+++ b/dcap/ql/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/dcap/quoteverify/sys/Cargo.toml
+++ b/dcap/quoteverify/sys/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-dcap-quoteverify-sys-types = { path = "types", version = "=0.1.0" }
 mc-sgx-dcap-sys-types = { path = "../../../dcap/sys/types", version = "=0.1.0" }

--- a/dcap/quoteverify/sys/types/Cargo.toml
+++ b/dcap/quoteverify/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-dcap-sys-types = { path = "../../../sys/types", version = "=0.1.0" }
 

--- a/dcap/sys/types/Cargo.toml
+++ b/dcap/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 

--- a/dcap/tvl/sys/Cargo.toml
+++ b/dcap/tvl/sys/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.62.1"
 [lib]
 # test false due to needing an enclave to fully link
 test = false
+doctest = false
 
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }

--- a/dcap/tvl/sys/src/lib.rs
+++ b/dcap/tvl/sys/src/lib.rs
@@ -2,7 +2,12 @@
 
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
+#![allow(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    rustdoc::broken_intra_doc_links
+)]
 
 use mc_sgx_core_sys_types::sgx_isv_svn_t;
 use mc_sgx_dcap_sys_types::{quote3_error_t, sgx_ql_qe_report_info_t, sgx_ql_qv_result_t, time_t};

--- a/tcrypto/sys/Cargo.toml
+++ b/tcrypto/sys/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
 mc-sgx-tcrypto-sys-types = { path = "types", version = "=0.1.0" }

--- a/tcrypto/sys/src/lib.rs
+++ b/tcrypto/sys/src/lib.rs
@@ -3,7 +3,12 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![feature(c_size_t)]
-#![allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
+#![allow(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    rustdoc::broken_intra_doc_links
+)]
 
 use core::ffi::c_size_t as size_t;
 use mc_sgx_core_sys_types::sgx_status_t;

--- a/tcrypto/sys/types/Cargo.toml
+++ b/tcrypto/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/trts/sys/Cargo.toml
+++ b/trts/sys/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.62.1"
 [lib]
 # test false due to needing an enclave to fully link
 test = false
+doctest = false
 
 [features]
 default = []

--- a/tservice/sys/Cargo.toml
+++ b/tservice/sys/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-tservice-sys-types = { path = "types", version = "=0.1.0" }
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }

--- a/tservice/sys/types/Cargo.toml
+++ b/tservice/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 mc-sgx-tcrypto-sys-types = { path = "../../../tcrypto/sys/types", version = "=0.1.0" }

--- a/tstdc/sys/Cargo.toml
+++ b/tstdc/sys/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.62.1"
 [lib]
 # test false due to needing trts, and thus an enclave to fully link
 test = false
+doctest = false
 
 [dependencies]
 mc-sgx-tstdc-sys-types = { path = "types", version = "0.1.0" }

--- a/tstdc/sys/types/Cargo.toml
+++ b/tstdc/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"

--- a/urts/sys/Cargo.toml
+++ b/urts/sys/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [features]
 sim = []
 default = []

--- a/urts/sys/types/Cargo.toml
+++ b/urts/sys/types/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
+[lib]
+doctest = false
+
 [dependencies]
 mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 


### PR DESCRIPTION
- Turn bindgen docs back on
- Disable doctests in bindgen-using crates
- Fix some lint issues in a couple crates
