### PR TITLE
ResultFrom/ResultInto

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,7 +115,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    if: failure()
+    if: failure() && ${{ github.event_name }} == 'push'
     needs:
       - rustfmt
       - markdown-lint
@@ -134,6 +134,6 @@ jobs:
           title: "Workflow: ${{ github.workflow }}"
           url: ${{ github.repository_url }}/actions/runs/${{ github.run_id }}
           description: |
-            gh:@${{ github.actor }} should triage this failure in ${{ github.repository }}, which was started by a ${{ github.event_name }}.
+            [@${{ github.pusher }}](${{ github.url }}/${{ github.pusher }}] was the last one to touch ${{ github.repository }}, is all I'm saying...
           avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,4 +128,8 @@ jobs:
       - name: Notify Discord on failure
         uses: sarisia/actions-status-discord@v1
         with:
+          username: "Github Workflow Failed"
+          status: Failure
+          noprefix: true
+          avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,9 +118,9 @@ jobs:
     if: failure()
     needs:
       - rustfmt
+      - markdown-lint
       - clippy
       - nono
-      - markdown-lint
       - build
       - test
       - doc
@@ -128,8 +128,20 @@ jobs:
       - name: Notify Discord on failure
         uses: sarisia/actions-status-discord@v1
         with:
-          username: "Github Workflow Failed"
+          username: "Github Actions"
           status: Failure
-          noprefix: true
+          nodetail: true
+          title: "Workflow: rust"
+          description: |
+            The ${{ github.workflow }} workflow, triggered by ${{ github.actor }} via ${{ github.event_name }}, has failed.<br/>
+            | Job | Status |
+            | --- | ------ |
+            | rustfmt | ${{ needs.rustfmt.result }} |
+            | markdown-lint | ${{ needs.markdown-lint.result }} |
+            | clippy | ${{ needs.clippy.result }} |
+            | nono | ${{ needs.nono.result }} |
+            | build | ${{ needs.build.result }} |
+            | test | ${{ needs.test.result }} |
+            | doc | ${{ needs.doc.result }} |
           avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,17 +131,17 @@ jobs:
           username: "Github Actions"
           status: Failure
           nodetail: true
-          title: "Workflow: rust"
+          title: "Workflow: ${{ github.workflow }}"
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           description: |
-            The ${{ github.workflow }} workflow, triggered by ${{ github.actor }} via ${{ github.event_name }}, has failed.<br/>
-            | Job | Status |
-            | --- | ------ |
-            | rustfmt | ${{ needs.rustfmt.result }} |
-            | markdown-lint | ${{ needs.markdown-lint.result }} |
-            | clippy | ${{ needs.clippy.result }} |
-            | nono | ${{ needs.nono.result }} |
-            | build | ${{ needs.build.result }} |
-            | test | ${{ needs.test.result }} |
-            | doc | ${{ needs.doc.result }} |
+            ${{ github.actor }} should triage why the ${{ github.workflow }} workflow in ${{ github.repository }} has failed.
+
+            rustfmt: ${{ needs.rustfmt.result }}
+            markdown-lint: ${{ needs.markdown-lint.result }}
+            clippy: ${{ needs.clippy.result }}
+            nono: ${{ needs.nono.result }}
+            build: ${{ needs.build.result }}
+            test: ${{ needs.test.result }}
+            doc: ${{ needs.doc.result }}
           avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,16 +132,8 @@ jobs:
           status: Failure
           nodetail: true
           title: "Workflow: ${{ github.workflow }}"
-          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          url: ${{ github.repository_url }}/actions/runs/${{ github.run_id }}
           description: |
-            ${{ github.actor }} should triage why the ${{ github.workflow }} workflow in ${{ github.repository }} has failed.
-
-            rustfmt: ${{ needs.rustfmt.result }}
-            markdown-lint: ${{ needs.markdown-lint.result }}
-            clippy: ${{ needs.clippy.result }}
-            nono: ${{ needs.nono.result }}
-            build: ${{ needs.build.result }}
-            test: ${{ needs.test.result }}
-            doc: ${{ needs.doc.result }}
+            gh:@${{ github.actor }} should triage this failure in ${{ github.repository }}, which was started by a ${{ github.event_name }}.
           avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-util"
+version = "0.1.0"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,8 +337,8 @@ dependencies = [
  "mc-sgx-capable-sys",
  "mc-sgx-capable-sys-types",
  "mc-sgx-capable-types",
- "mc-sgx-core-sys-types",
  "mc-sgx-core-types",
+ "mc-sgx-util",
  "yare",
 ]
 
@@ -369,6 +369,7 @@ dependencies = [
  "displaydoc",
  "mc-sgx-capable-sys-types",
  "mc-sgx-core-types",
+ "mc-sgx-util",
  "serde",
  "yare",
 ]
@@ -397,6 +398,7 @@ dependencies = [
  "mc-sgx-core-sys-types",
  "rand",
  "rand_core",
+ "mc-sgx-util",
  "serde",
  "yare",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "mc-sgx-core-sys-types",
+ "mc-sgx-util",
  "rand",
  "rand_core",
- "mc-sgx-util",
  "serde",
  "yare",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "urts",
     "urts/sys",
     "urts/sys/types",
+    "util",
 ]
 exclude = [
     "test_enclave",

--- a/capable/Cargo.toml
+++ b/capable/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.1.0" }
-mc-sgx-core-types = { path = "../core/types", version = "=0.1.0" }
 mc-sgx-capable-sys = { path = "sys", version = "=0.1.0" }
 mc-sgx-capable-sys-types = { path = "sys/types", version = "=0.1.0" }
 mc-sgx-capable-types = { path = "types", version = "=0.1.0" }
+mc-sgx-core-types = { path = "../core/types", version = "=0.1.0" }
+mc-sgx-util = { path = "../util", version = "=0.1.0" }
 
 [dev-dependencies]
 yare = "1.0.1"

--- a/capable/src/lib.rs
+++ b/capable/src/lib.rs
@@ -24,8 +24,9 @@ pub fn is_capable() -> Result<bool> {
 /// This function requires running the untrusted userspace application as an
 /// administrator.
 ///
-/// Returns `Ok(())` when SGX is enable, or an [Error] indicating what would
-/// need to happen to turn it on.
+/// Returns `Ok(())` when SGX is enable, or an
+/// [`Error`](mc_sgx_capable_types::Error) indicating what would need to happen
+/// to turn it on.
 pub fn is_enabled() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 
@@ -41,8 +42,9 @@ pub fn is_enabled() -> Result<()> {
 /// This function requires running the untrusted userspace application as an
 /// administrator.
 ///
-/// Returns `Ok(())` if SGX is now enabled, or an [Error] indicating what would
-/// need to happen to turn it on.
+/// Returns `Ok(())` if SGX is now enabled, or an
+/// [`Error`](mc_sgx_capable_types::Error) indicating what would need to happen
+/// to turn it on.
 pub fn enable() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 

--- a/capable/src/lib.rs
+++ b/capable/src/lib.rs
@@ -3,9 +3,9 @@
 #![doc = include_str!("../README.md")]
 
 use mc_sgx_capable_sys_types::sgx_device_status_t;
-use mc_sgx_capable_types::{Error, Result};
-use mc_sgx_core_sys_types::sgx_status_t;
+use mc_sgx_capable_types::Result;
 use mc_sgx_core_types::Error as SgxError;
+use mc_sgx_util::{ResultFrom, ResultInto};
 
 /// Tests if the current system is capable of running SGX.
 ///
@@ -13,26 +13,10 @@ use mc_sgx_core_types::Error as SgxError;
 /// administrator.
 pub fn is_capable() -> Result<bool> {
     let mut value = 0;
-    let status = unsafe { mc_sgx_capable_sys::sgx_is_capable(&mut value as *mut _) };
-    if status == sgx_status_t::SGX_SUCCESS {
-        Ok(value == 1)
-    } else {
-        Err(Error::from(SgxError::from(status)))
-    }
-}
 
-// FIXME: Make the whole process of going from a status to a result way more
-//        monadic.
-fn handle_retval(status: sgx_status_t, device_status: sgx_device_status_t) -> Result<()> {
-    if status == sgx_status_t::SGX_SUCCESS {
-        if let Ok(err) = Error::try_from(device_status) {
-            Err(err)
-        } else {
-            Ok(())
-        }
-    } else {
-        Err(SgxError::from(status).into())
-    }
+    SgxError::result_from(unsafe { mc_sgx_capable_sys::sgx_is_capable(&mut value as *mut _) })?;
+
+    Ok(value == 1)
 }
 
 /// Attempts to see if SGX is enabled.
@@ -45,8 +29,11 @@ fn handle_retval(status: sgx_status_t, device_status: sgx_device_status_t) -> Re
 pub fn is_enabled() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 
-    let status = unsafe { mc_sgx_capable_sys::sgx_cap_get_status(&mut device_status as *mut _) };
-    handle_retval(status, device_status)
+    SgxError::result_from(unsafe {
+        mc_sgx_capable_sys::sgx_cap_get_status(&mut device_status as *mut _)
+    })?;
+
+    device_status.into_result()
 }
 
 /// Attempt to enable SGX programmatically.
@@ -59,27 +46,8 @@ pub fn is_enabled() -> Result<()> {
 pub fn enable() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 
-    let status = unsafe { mc_sgx_capable_sys::sgx_cap_enable_device(&mut device_status as *mut _) };
-    handle_retval(status, device_status)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use yare::parameterized;
-
-    #[parameterized(
-        ok = { sgx_status_t::SGX_SUCCESS, sgx_device_status_t::SGX_ENABLED, Ok(()) },
-        status_fail = { sgx_status_t::SGX_ERROR_UNEXPECTED, sgx_device_status_t::SGX_ENABLED, Err(Error::Sgx(SgxError::Unexpected)) },
-        no_priviledge = { sgx_status_t::SGX_ERROR_NO_PRIVILEGE, sgx_device_status_t::SGX_ENABLED, Err(Error::Sgx(SgxError::NoPrivilege)) },
-        status_fail_has_precedence = { sgx_status_t::SGX_ERROR_NO_PRIVILEGE, sgx_device_status_t::SGX_DISABLED_MANUAL_ENABLE, Err(Error::Sgx(SgxError::NoPrivilege)) },
-        device_status_fail = { sgx_status_t::SGX_SUCCESS, sgx_device_status_t::SGX_DISABLED_MANUAL_ENABLE, Err(Error::ManualEnable) },
-    )]
-    fn return_value_mapping(
-        status: sgx_status_t,
-        device_status: sgx_device_status_t,
-        expected: Result<()>,
-    ) {
-        assert_eq!(handle_retval(status, device_status), expected);
-    }
+    SgxError::result_from(unsafe {
+        mc_sgx_capable_sys::sgx_cap_enable_device(&mut device_status as *mut _)
+    })?;
+    device_status.into_result()
 }

--- a/capable/src/lib.rs
+++ b/capable/src/lib.rs
@@ -3,9 +3,8 @@
 #![doc = include_str!("../README.md")]
 
 use mc_sgx_capable_sys_types::sgx_device_status_t;
-use mc_sgx_capable_types::Result;
-use mc_sgx_core_types::Error as SgxError;
-use mc_sgx_util::{ResultFrom, ResultInto};
+use mc_sgx_capable_types::{Error, Result};
+use mc_sgx_util::ResultInto;
 
 /// Tests if the current system is capable of running SGX.
 ///
@@ -14,9 +13,10 @@ use mc_sgx_util::{ResultFrom, ResultInto};
 pub fn is_capable() -> Result<bool> {
     let mut value = 0;
 
-    SgxError::result_from(unsafe { mc_sgx_capable_sys::sgx_is_capable(&mut value as *mut _) })?;
-
-    Ok(value == 1)
+    unsafe { mc_sgx_capable_sys::sgx_is_capable(&mut value as *mut _) }
+        .into_result()
+        .map_err(Error::from)
+        .map(|_| value == 1)
 }
 
 /// Attempts to see if SGX is enabled.
@@ -30,11 +30,10 @@ pub fn is_capable() -> Result<bool> {
 pub fn is_enabled() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 
-    SgxError::result_from(unsafe {
-        mc_sgx_capable_sys::sgx_cap_get_status(&mut device_status as *mut _)
-    })?;
-
-    device_status.into_result()
+    unsafe { mc_sgx_capable_sys::sgx_cap_get_status(&mut device_status as *mut _) }
+        .into_result()
+        .map_err(Error::from)
+        .and_then(|_| device_status.into_result())
 }
 
 /// Attempt to enable SGX programmatically.
@@ -48,8 +47,8 @@ pub fn is_enabled() -> Result<()> {
 pub fn enable() -> Result<()> {
     let mut device_status = sgx_device_status_t::SGX_DISABLED;
 
-    SgxError::result_from(unsafe {
-        mc_sgx_capable_sys::sgx_cap_enable_device(&mut device_status as *mut _)
-    })?;
-    device_status.into_result()
+    unsafe { mc_sgx_capable_sys::sgx_cap_enable_device(&mut device_status as *mut _) }
+        .into_result()
+        .map_err(Error::from)
+        .and_then(|_| device_status.into_result())
 }

--- a/capable/types/Cargo.toml
+++ b/capable/types/Cargo.toml
@@ -23,6 +23,7 @@ serde = [
 displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-capable-sys-types = { path = "../sys/types", version = "=0.1.0" }
 mc-sgx-core-types = { path = "../../core/types", version = "=0.1.0" }
+mc-sgx-util = { path = "../../util", version = "=0.1.0" }
 serde = { version = "1.0.144", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/capable/types/src/lib.rs
+++ b/capable/types/src/lib.rs
@@ -7,7 +7,7 @@
 use core::result::Result as CoreResult;
 use mc_sgx_capable_sys_types::sgx_device_status_t;
 use mc_sgx_core_types::Error as SgxError;
-use mc_sgx_util::ResultFrom;
+use mc_sgx_util::{ResultFrom, ResultInto};
 
 /// Convenience type for handling SGX capable results
 pub type Result<T> = CoreResult<T, Error>;
@@ -90,6 +90,7 @@ impl TryFrom<sgx_device_status_t> for Error {
 }
 
 impl ResultFrom<sgx_device_status_t> for Error {}
+impl ResultInto<Error> for sgx_device_status_t {}
 
 #[cfg(test)]
 mod test {

--- a/capable/types/src/lib.rs
+++ b/capable/types/src/lib.rs
@@ -54,7 +54,8 @@ impl From<SgxError> for Error {
 ///
 /// As a result, we need to use this here, so the preferred way to actually do
 /// FFI with this is best done via
-/// [`ResultFrom`](mc_sgx_util::ResultFrom) or [`ResultInto`]implementation.
+/// [`ResultFrom`](mc_sgx_util::ResultFrom) or
+/// [`ResultInto`](mc_sgx_util::ResultInto) implementation.
 ///
 /// # Example
 ///

--- a/capable/types/src/lib.rs
+++ b/capable/types/src/lib.rs
@@ -50,7 +50,7 @@ impl From<SgxError> for Error {
 ///
 /// This is fallible because device_status_t also includes
 /// [`SGX_ENABLED`](mc_sgx_capable_sys_types::sgx_device_status_t::SGX_ENABLED),
-/// which is (obviously) not an error.
+/// which is not an error.
 ///
 /// As a result, we need to use this here, so the preferred way to actually do
 /// FFI with this is best done via

--- a/capable/types/src/lib.rs
+++ b/capable/types/src/lib.rs
@@ -95,19 +95,20 @@ impl ResultFrom<sgx_device_status_t> for Error {}
 #[cfg(test)]
 mod test {
     use super::*;
+    use mc_sgx_util::ResultInto;
     use yare::parameterized;
 
     #[parameterized(
-        enabled = { sgx_device_status_t::SGX_ENABLED, Err(()) },
-        reboot_required = { sgx_device_status_t::SGX_DISABLED_REBOOT_REQUIRED, Ok(Error::RebootRequired) },
-        legacy_os = { sgx_device_status_t::SGX_DISABLED_LEGACY_OS, Ok(Error::LegacyOs) },
-        disabled = { sgx_device_status_t::SGX_DISABLED, Ok(Error::Disabled) },
-        sci_available = { sgx_device_status_t::SGX_DISABLED_SCI_AVAILABLE, Ok(Error::SciAvailable) },
-        manual_enable = { sgx_device_status_t::SGX_DISABLED_MANUAL_ENABLE, Ok(Error::ManualEnable) },
-        hyperv_enabled = { sgx_device_status_t::SGX_DISABLED_HYPERV_ENABLED, Ok(Error::HyperVEnabled) },
-        unsupported_cpu = { sgx_device_status_t::SGX_DISABLED_UNSUPPORTED_CPU, Ok(Error::UnsupportedCpu) },
+        enabled = { sgx_device_status_t::SGX_ENABLED, Ok(()) },
+        reboot_required = { sgx_device_status_t::SGX_DISABLED_REBOOT_REQUIRED, Err(Error::RebootRequired) },
+        legacy_os = { sgx_device_status_t::SGX_DISABLED_LEGACY_OS, Err(Error::LegacyOs) },
+        disabled = { sgx_device_status_t::SGX_DISABLED, Err(Error::Disabled) },
+        sci_available = { sgx_device_status_t::SGX_DISABLED_SCI_AVAILABLE, Err(Error::SciAvailable) },
+        manual_enable = { sgx_device_status_t::SGX_DISABLED_MANUAL_ENABLE, Err(Error::ManualEnable) },
+        hyperv_enabled = { sgx_device_status_t::SGX_DISABLED_HYPERV_ENABLED, Err(Error::HyperVEnabled) },
+        unsupported_cpu = { sgx_device_status_t::SGX_DISABLED_UNSUPPORTED_CPU, Err(Error::UnsupportedCpu) },
     )]
-    fn status_try_into_error(actual: sgx_device_status_t, expected: CoreResult<Error, ()>) {
-        assert_eq!(Error::try_from(actual), expected);
+    fn device_status_into_result(actual: sgx_device_status_t, expected: CoreResult<(), Error>) {
+        assert_eq!(actual.into_result(), expected);
     }
 }

--- a/capable/types/src/lib.rs
+++ b/capable/types/src/lib.rs
@@ -53,23 +53,21 @@ impl From<SgxError> for Error {
 /// which is (obviously) not an error.
 ///
 /// As a result, we need to use this here, so the preferred way to actually do
-/// FFI with this is best done via the blanket
-/// [`ResultInto`](mc_sgx_util::ResultInto) implementation.
+/// FFI with this is best done via
+/// [`ResultFrom`](mc_sgx_util::ResultFrom) or [`ResultInto`]implementation.
 ///
 /// # Example
 ///
 /// ```
 /// use mc_sgx_capable_sys_types::sgx_device_status_t;
-/// use mc_sgx_capable_types::Result;
-/// use mc_sgx_util::ResultInto;
+/// use mc_sgx_capable_types::{Error, Result};
+/// use mc_sgx_util::ResultFrom;
 ///
 /// fn foo() -> Result<bool> {
 ///     let device_status = sgx_device_status_t::SGX_DISABLED;
 ///
-///     // Convert the status into a `Result<(), Err>`
-///     device_status.into_result()?;
-///
-///     Ok(true)
+///     // Convert the status into a `Result<(), Err>`, change () to true
+///     Error::result_from(device_status).map(|_| true)
 /// }
 /// ```
 impl TryFrom<sgx_device_status_t> for Error {

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -21,6 +21,7 @@ serde = [
 [dependencies]
 bitflags = "1.3.2"
 mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.1.0" }
+mc-sgx-util = { path = "../../util", version = "=0.1.0" }
 rand_core = { version = "0.6.3", default-features = false }
 serde = { version = "1.0.144", default-features = false, features = ["derive"], optional = true }
 

--- a/core/types/src/error.rs
+++ b/core/types/src/error.rs
@@ -394,6 +394,6 @@ mod test {
 
     #[test]
     fn success_is_not_an_error() {
-        assert!(Error::try_from(sgx_status_t::SGX_SUCCESS).is_err())
+        assert!(sgx_status_t::SGX_SUCCESS.into_result().is_ok())
     }
 }

--- a/core/types/src/error.rs
+++ b/core/types/src/error.rs
@@ -2,8 +2,9 @@
 
 //! SGX Error types
 
-use core::convert::From;
+use core::result::Result as CoreResult;
 use mc_sgx_core_sys_types::sgx_status_t;
+use mc_sgx_util::ResultFrom;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -15,6 +16,9 @@ pub enum FfiError {
     /// Happens when a value that is not represented by the known C enum values.
     UnknownEnumValue(i64),
 }
+
+/// A convenience type alias for a `Result` which contains an [`Error`].
+pub type Result<T> = CoreResult<T, Error>;
 
 /// A enumeration of SGX errors.
 ///
@@ -231,111 +235,119 @@ pub enum Error {
     EnclaveCreateInterrupted,
 }
 
-impl From<sgx_status_t> for Error {
-    fn from(src: sgx_status_t) -> Error {
+impl TryFrom<sgx_status_t> for Error {
+    type Error = ();
+
+    fn try_from(src: sgx_status_t) -> CoreResult<Error, ()> {
         match src {
+            sgx_status_t::SGX_SUCCESS => Err(()),
+
             // 0x0001 - 0x0fff: Generic errors
-            sgx_status_t::SGX_ERROR_UNEXPECTED => Error::Unexpected,
-            sgx_status_t::SGX_ERROR_INVALID_PARAMETER => Error::InvalidParameter,
-            sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => Error::OutOfMemory,
-            sgx_status_t::SGX_ERROR_ENCLAVE_LOST => Error::EnclaveLost,
-            sgx_status_t::SGX_ERROR_INVALID_STATE => Error::InvalidState,
-            sgx_status_t::SGX_ERROR_FEATURE_NOT_SUPPORTED => Error::FeatureNotSupported,
-            sgx_status_t::SGX_PTHREAD_EXIT => Error::ThreadExit,
-            sgx_status_t::SGX_ERROR_MEMORY_MAP_FAILURE => Error::MemoryMapFailure,
+            sgx_status_t::SGX_ERROR_UNEXPECTED => Ok(Error::Unexpected),
+            sgx_status_t::SGX_ERROR_INVALID_PARAMETER => Ok(Error::InvalidParameter),
+            sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => Ok(Error::OutOfMemory),
+            sgx_status_t::SGX_ERROR_ENCLAVE_LOST => Ok(Error::EnclaveLost),
+            sgx_status_t::SGX_ERROR_INVALID_STATE => Ok(Error::InvalidState),
+            sgx_status_t::SGX_ERROR_FEATURE_NOT_SUPPORTED => Ok(Error::FeatureNotSupported),
+            sgx_status_t::SGX_PTHREAD_EXIT => Ok(Error::ThreadExit),
+            sgx_status_t::SGX_ERROR_MEMORY_MAP_FAILURE => Ok(Error::MemoryMapFailure),
 
             // 0x1001 - 0x1fff: Fatal runtime errors
-            sgx_status_t::SGX_ERROR_INVALID_FUNCTION => Error::InvalidFunction,
-            sgx_status_t::SGX_ERROR_OUT_OF_TCS => Error::OutOfTcs,
-            sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED => Error::EnclaveCrashed,
-            sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED => Error::EcallNotAllowed,
-            sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED => Error::OcallNotAllowed,
-            sgx_status_t::SGX_ERROR_STACK_OVERRUN => Error::StackOverrun,
+            sgx_status_t::SGX_ERROR_INVALID_FUNCTION => Ok(Error::InvalidFunction),
+            sgx_status_t::SGX_ERROR_OUT_OF_TCS => Ok(Error::OutOfTcs),
+            sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED => Ok(Error::EnclaveCrashed),
+            sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED => Ok(Error::EcallNotAllowed),
+            sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED => Ok(Error::OcallNotAllowed),
+            sgx_status_t::SGX_ERROR_STACK_OVERRUN => Ok(Error::StackOverrun),
 
             // 0x2000 - 0x2fff: Enclave construction errors
-            sgx_status_t::SGX_ERROR_UNDEFINED_SYMBOL => Error::UndefinedSymbol,
-            sgx_status_t::SGX_ERROR_INVALID_ENCLAVE => Error::InvalidEnclave,
-            sgx_status_t::SGX_ERROR_INVALID_ENCLAVE_ID => Error::InvalidEnclaveId,
-            sgx_status_t::SGX_ERROR_INVALID_SIGNATURE => Error::InvalidSignature,
-            sgx_status_t::SGX_ERROR_NDEBUG_ENCLAVE => Error::NdebugEnclave,
-            sgx_status_t::SGX_ERROR_OUT_OF_EPC => Error::OutOfEpc,
-            sgx_status_t::SGX_ERROR_NO_DEVICE => Error::NoDevice,
-            sgx_status_t::SGX_ERROR_MEMORY_MAP_CONFLICT => Error::MemoryMapConflict,
-            sgx_status_t::SGX_ERROR_INVALID_METADATA => Error::InvalidMetadata,
-            sgx_status_t::SGX_ERROR_DEVICE_BUSY => Error::DeviceBusy,
-            sgx_status_t::SGX_ERROR_INVALID_VERSION => Error::InvalidVersion,
-            sgx_status_t::SGX_ERROR_MODE_INCOMPATIBLE => Error::ModeIncompatible,
-            sgx_status_t::SGX_ERROR_ENCLAVE_FILE_ACCESS => Error::EnclaveFileAccess,
-            sgx_status_t::SGX_ERROR_INVALID_MISC => Error::InvalidMisc,
-            sgx_status_t::SGX_ERROR_INVALID_LAUNCH_TOKEN => Error::InvalidLaunchToken,
+            sgx_status_t::SGX_ERROR_UNDEFINED_SYMBOL => Ok(Error::UndefinedSymbol),
+            sgx_status_t::SGX_ERROR_INVALID_ENCLAVE => Ok(Error::InvalidEnclave),
+            sgx_status_t::SGX_ERROR_INVALID_ENCLAVE_ID => Ok(Error::InvalidEnclaveId),
+            sgx_status_t::SGX_ERROR_INVALID_SIGNATURE => Ok(Error::InvalidSignature),
+            sgx_status_t::SGX_ERROR_NDEBUG_ENCLAVE => Ok(Error::NdebugEnclave),
+            sgx_status_t::SGX_ERROR_OUT_OF_EPC => Ok(Error::OutOfEpc),
+            sgx_status_t::SGX_ERROR_NO_DEVICE => Ok(Error::NoDevice),
+            sgx_status_t::SGX_ERROR_MEMORY_MAP_CONFLICT => Ok(Error::MemoryMapConflict),
+            sgx_status_t::SGX_ERROR_INVALID_METADATA => Ok(Error::InvalidMetadata),
+            sgx_status_t::SGX_ERROR_DEVICE_BUSY => Ok(Error::DeviceBusy),
+            sgx_status_t::SGX_ERROR_INVALID_VERSION => Ok(Error::InvalidVersion),
+            sgx_status_t::SGX_ERROR_MODE_INCOMPATIBLE => Ok(Error::ModeIncompatible),
+            sgx_status_t::SGX_ERROR_ENCLAVE_FILE_ACCESS => Ok(Error::EnclaveFileAccess),
+            sgx_status_t::SGX_ERROR_INVALID_MISC => Ok(Error::InvalidMisc),
+            sgx_status_t::SGX_ERROR_INVALID_LAUNCH_TOKEN => Ok(Error::InvalidLaunchToken),
 
             // 0x3001-0x3fff: Report verification
-            sgx_status_t::SGX_ERROR_MAC_MISMATCH => Error::MacMismatch,
-            sgx_status_t::SGX_ERROR_INVALID_ATTRIBUTE => Error::InvalidAttribute,
-            sgx_status_t::SGX_ERROR_INVALID_CPUSVN => Error::InvalidCpuSvn,
-            sgx_status_t::SGX_ERROR_INVALID_ISVSVN => Error::InvalidIsvSvn,
-            sgx_status_t::SGX_ERROR_INVALID_KEYNAME => Error::InvalidKeyname,
+            sgx_status_t::SGX_ERROR_MAC_MISMATCH => Ok(Error::MacMismatch),
+            sgx_status_t::SGX_ERROR_INVALID_ATTRIBUTE => Ok(Error::InvalidAttribute),
+            sgx_status_t::SGX_ERROR_INVALID_CPUSVN => Ok(Error::InvalidCpuSvn),
+            sgx_status_t::SGX_ERROR_INVALID_ISVSVN => Ok(Error::InvalidIsvSvn),
+            sgx_status_t::SGX_ERROR_INVALID_KEYNAME => Ok(Error::InvalidKeyname),
 
             // 0x4000 - 0x4fff: AESM
-            sgx_status_t::SGX_ERROR_SERVICE_UNAVAILABLE => Error::ServiceUnavailable,
-            sgx_status_t::SGX_ERROR_SERVICE_TIMEOUT => Error::ServiceTimeout,
-            sgx_status_t::SGX_ERROR_AE_INVALID_EPIDBLOB => Error::AeInvalidEpidblob,
-            sgx_status_t::SGX_ERROR_SERVICE_INVALID_PRIVILEGE => Error::ServiceInvalidPrivilege,
-            sgx_status_t::SGX_ERROR_EPID_MEMBER_REVOKED => Error::EpidMemberRevoked,
-            sgx_status_t::SGX_ERROR_UPDATE_NEEDED => Error::UpdateNeeded,
-            sgx_status_t::SGX_ERROR_NETWORK_FAILURE => Error::NetworkFailure,
-            sgx_status_t::SGX_ERROR_AE_SESSION_INVALID => Error::AeSessionInvalid,
-            sgx_status_t::SGX_ERROR_BUSY => Error::Busy,
-            sgx_status_t::SGX_ERROR_MC_NOT_FOUND => Error::McNotFound,
-            sgx_status_t::SGX_ERROR_MC_NO_ACCESS_RIGHT => Error::McNoAccessRight,
-            sgx_status_t::SGX_ERROR_MC_USED_UP => Error::McUsedUp,
-            sgx_status_t::SGX_ERROR_MC_OVER_QUOTA => Error::McOverQuota,
-            sgx_status_t::SGX_ERROR_KDF_MISMATCH => Error::KdfMismatch,
-            sgx_status_t::SGX_ERROR_UNRECOGNIZED_PLATFORM => Error::UnrecognizedPlatform,
-            sgx_status_t::SGX_ERROR_UNSUPPORTED_CONFIG => Error::UnsupportedConfig,
+            sgx_status_t::SGX_ERROR_SERVICE_UNAVAILABLE => Ok(Error::ServiceUnavailable),
+            sgx_status_t::SGX_ERROR_SERVICE_TIMEOUT => Ok(Error::ServiceTimeout),
+            sgx_status_t::SGX_ERROR_AE_INVALID_EPIDBLOB => Ok(Error::AeInvalidEpidblob),
+            sgx_status_t::SGX_ERROR_SERVICE_INVALID_PRIVILEGE => Ok(Error::ServiceInvalidPrivilege),
+            sgx_status_t::SGX_ERROR_EPID_MEMBER_REVOKED => Ok(Error::EpidMemberRevoked),
+            sgx_status_t::SGX_ERROR_UPDATE_NEEDED => Ok(Error::UpdateNeeded),
+            sgx_status_t::SGX_ERROR_NETWORK_FAILURE => Ok(Error::NetworkFailure),
+            sgx_status_t::SGX_ERROR_AE_SESSION_INVALID => Ok(Error::AeSessionInvalid),
+            sgx_status_t::SGX_ERROR_BUSY => Ok(Error::Busy),
+            sgx_status_t::SGX_ERROR_MC_NOT_FOUND => Ok(Error::McNotFound),
+            sgx_status_t::SGX_ERROR_MC_NO_ACCESS_RIGHT => Ok(Error::McNoAccessRight),
+            sgx_status_t::SGX_ERROR_MC_USED_UP => Ok(Error::McUsedUp),
+            sgx_status_t::SGX_ERROR_MC_OVER_QUOTA => Ok(Error::McOverQuota),
+            sgx_status_t::SGX_ERROR_KDF_MISMATCH => Ok(Error::KdfMismatch),
+            sgx_status_t::SGX_ERROR_UNRECOGNIZED_PLATFORM => Ok(Error::UnrecognizedPlatform),
+            sgx_status_t::SGX_ERROR_UNSUPPORTED_CONFIG => Ok(Error::UnsupportedConfig),
 
             // 0x5000 - 0x5fff: AESM-internal errors
-            sgx_status_t::SGX_ERROR_NO_PRIVILEGE => Error::NoPrivilege,
+            sgx_status_t::SGX_ERROR_NO_PRIVILEGE => Ok(Error::NoPrivilege),
 
             // 0x6000 - 0x6fff: Encrypted Enclaves
-            sgx_status_t::SGX_ERROR_PCL_ENCRYPTED => Error::PclEncrypted,
-            sgx_status_t::SGX_ERROR_PCL_NOT_ENCRYPTED => Error::PclNotEncrypted,
-            sgx_status_t::SGX_ERROR_PCL_MAC_MISMATCH => Error::PclMacMismatch,
-            sgx_status_t::SGX_ERROR_PCL_SHA_MISMATCH => Error::PclShaMismatch,
-            sgx_status_t::SGX_ERROR_PCL_GUID_MISMATCH => Error::PclGuidMismatch,
+            sgx_status_t::SGX_ERROR_PCL_ENCRYPTED => Ok(Error::PclEncrypted),
+            sgx_status_t::SGX_ERROR_PCL_NOT_ENCRYPTED => Ok(Error::PclNotEncrypted),
+            sgx_status_t::SGX_ERROR_PCL_MAC_MISMATCH => Ok(Error::PclMacMismatch),
+            sgx_status_t::SGX_ERROR_PCL_SHA_MISMATCH => Ok(Error::PclShaMismatch),
+            sgx_status_t::SGX_ERROR_PCL_GUID_MISMATCH => Ok(Error::PclGuidMismatch),
 
             // 0x7000 - 0x7fff: SGX Encrypted FS
-            sgx_status_t::SGX_ERROR_FILE_BAD_STATUS => Error::FileBadStatus,
-            sgx_status_t::SGX_ERROR_FILE_NO_KEY_ID => Error::FileNoKeyId,
-            sgx_status_t::SGX_ERROR_FILE_NAME_MISMATCH => Error::FileNameMismatch,
-            sgx_status_t::SGX_ERROR_FILE_NOT_SGX_FILE => Error::FileNotSgxFile,
-            sgx_status_t::SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE => Error::FileCantOpenRecoveryFile,
-            sgx_status_t::SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE => {
-                Error::FileCantWriteRecoveryFile
+            sgx_status_t::SGX_ERROR_FILE_BAD_STATUS => Ok(Error::FileBadStatus),
+            sgx_status_t::SGX_ERROR_FILE_NO_KEY_ID => Ok(Error::FileNoKeyId),
+            sgx_status_t::SGX_ERROR_FILE_NAME_MISMATCH => Ok(Error::FileNameMismatch),
+            sgx_status_t::SGX_ERROR_FILE_NOT_SGX_FILE => Ok(Error::FileNotSgxFile),
+            sgx_status_t::SGX_ERROR_FILE_CANT_OPEN_RECOVERY_FILE => {
+                Ok(Error::FileCantOpenRecoveryFile)
             }
-            sgx_status_t::SGX_ERROR_FILE_RECOVERY_NEEDED => Error::FileRecoveryNeeded,
-            sgx_status_t::SGX_ERROR_FILE_FLUSH_FAILED => Error::FileFlushFailed,
-            sgx_status_t::SGX_ERROR_FILE_CLOSE_FAILED => Error::FileCloseFailed,
+            sgx_status_t::SGX_ERROR_FILE_CANT_WRITE_RECOVERY_FILE => {
+                Ok(Error::FileCantWriteRecoveryFile)
+            }
+            sgx_status_t::SGX_ERROR_FILE_RECOVERY_NEEDED => Ok(Error::FileRecoveryNeeded),
+            sgx_status_t::SGX_ERROR_FILE_FLUSH_FAILED => Ok(Error::FileFlushFailed),
+            sgx_status_t::SGX_ERROR_FILE_CLOSE_FAILED => Ok(Error::FileCloseFailed),
 
             // 0x8000-0x8fff: Custom Attestation support
-            sgx_status_t::SGX_ERROR_UNSUPPORTED_ATT_KEY_ID => Error::UnsupportedAttKeyId,
+            sgx_status_t::SGX_ERROR_UNSUPPORTED_ATT_KEY_ID => Ok(Error::UnsupportedAttKeyId),
             sgx_status_t::SGX_ERROR_ATT_KEY_CERTIFICATION_FAILURE => {
-                Error::AttKeyCertificationFailure
+                Ok(Error::AttKeyCertificationFailure)
             }
-            sgx_status_t::SGX_ERROR_ATT_KEY_UNINITIALIZED => Error::AttKeyUninitialized,
-            sgx_status_t::SGX_ERROR_INVALID_ATT_KEY_CERT_DATA => Error::InvalidAttKeyCertData,
-            sgx_status_t::SGX_ERROR_PLATFORM_CERT_UNAVAILABLE => Error::PlatformCertUnavailable,
+            sgx_status_t::SGX_ERROR_ATT_KEY_UNINITIALIZED => Ok(Error::AttKeyUninitialized),
+            sgx_status_t::SGX_ERROR_INVALID_ATT_KEY_CERT_DATA => Ok(Error::InvalidAttKeyCertData),
+            sgx_status_t::SGX_ERROR_PLATFORM_CERT_UNAVAILABLE => Ok(Error::PlatformCertUnavailable),
 
             // 0xf000-0xffff: Internal-to-SGX errors
             sgx_status_t::SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED => {
-                Error::EnclaveCreateInterrupted
+                Ok(Error::EnclaveCreateInterrupted)
             }
 
             // Map all unknowns to the unexpected error
-            _ => Error::Unexpected,
+            _ => Ok(Error::Unexpected),
         }
     }
 }
+
+impl ResultFrom<sgx_status_t> for Error {}
 
 #[cfg(test)]
 mod test {
@@ -344,34 +356,43 @@ mod test {
     use super::*;
 
     #[parameterized(
-    unexpected = { sgx_status_t::SGX_ERROR_UNEXPECTED, Error::Unexpected },
-    memory_map = { sgx_status_t::SGX_ERROR_MEMORY_MAP_FAILURE, Error::MemoryMapFailure },
-    invalid_function = { sgx_status_t::SGX_ERROR_INVALID_FUNCTION, Error::InvalidFunction },
-    stack_overrun = { sgx_status_t::SGX_ERROR_STACK_OVERRUN, Error::StackOverrun },
-    undefined_symbol = { sgx_status_t::SGX_ERROR_UNDEFINED_SYMBOL, Error::UndefinedSymbol },
-    invalid_launch_token = { sgx_status_t::SGX_ERROR_INVALID_LAUNCH_TOKEN, Error::InvalidLaunchToken },
-    mac_mismatch = { sgx_status_t::SGX_ERROR_MAC_MISMATCH, Error::MacMismatch },
-    invalid_keyname = { sgx_status_t::SGX_ERROR_INVALID_KEYNAME, Error::InvalidKeyname },
-    service_unavailable = { sgx_status_t::SGX_ERROR_SERVICE_UNAVAILABLE, Error::ServiceUnavailable },
-    unsupported_config = { sgx_status_t::SGX_ERROR_UNSUPPORTED_CONFIG, Error::UnsupportedConfig },
-    no_privilege = { sgx_status_t::SGX_ERROR_NO_PRIVILEGE, Error::NoPrivilege },
-    pcl_encrypted = { sgx_status_t::SGX_ERROR_PCL_ENCRYPTED, Error::PclEncrypted },
-    pcl_guid_mismatch = { sgx_status_t::SGX_ERROR_PCL_GUID_MISMATCH, Error::PclGuidMismatch },
-    file_bad_status = { sgx_status_t::SGX_ERROR_FILE_BAD_STATUS, Error::FileBadStatus },
-    file_close_failed = { sgx_status_t::SGX_ERROR_FILE_CLOSE_FAILED, Error::FileCloseFailed },
-    unsupported_att_key_id = { sgx_status_t::SGX_ERROR_UNSUPPORTED_ATT_KEY_ID, Error::UnsupportedAttKeyId },
-    platform_cert_unavailable = { sgx_status_t::SGX_ERROR_PLATFORM_CERT_UNAVAILABLE, Error::PlatformCertUnavailable },
-    interrupted = { sgx_status_t::SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED, Error::EnclaveCreateInterrupted },
+        unexpected = { sgx_status_t::SGX_ERROR_UNEXPECTED, Error::Unexpected },
+        memory_map = { sgx_status_t::SGX_ERROR_MEMORY_MAP_FAILURE, Error::MemoryMapFailure },
+        invalid_function = { sgx_status_t::SGX_ERROR_INVALID_FUNCTION, Error::InvalidFunction },
+        stack_overrun = { sgx_status_t::SGX_ERROR_STACK_OVERRUN, Error::StackOverrun },
+        undefined_symbol = { sgx_status_t::SGX_ERROR_UNDEFINED_SYMBOL, Error::UndefinedSymbol },
+        invalid_launch_token = { sgx_status_t::SGX_ERROR_INVALID_LAUNCH_TOKEN, Error::InvalidLaunchToken },
+        mac_mismatch = { sgx_status_t::SGX_ERROR_MAC_MISMATCH, Error::MacMismatch },
+        invalid_keyname = { sgx_status_t::SGX_ERROR_INVALID_KEYNAME, Error::InvalidKeyname },
+        service_unavailable = { sgx_status_t::SGX_ERROR_SERVICE_UNAVAILABLE, Error::ServiceUnavailable },
+        unsupported_config = { sgx_status_t::SGX_ERROR_UNSUPPORTED_CONFIG, Error::UnsupportedConfig },
+        no_privilege = { sgx_status_t::SGX_ERROR_NO_PRIVILEGE, Error::NoPrivilege },
+        pcl_encrypted = { sgx_status_t::SGX_ERROR_PCL_ENCRYPTED, Error::PclEncrypted },
+        pcl_guid_mismatch = { sgx_status_t::SGX_ERROR_PCL_GUID_MISMATCH, Error::PclGuidMismatch },
+        file_bad_status = { sgx_status_t::SGX_ERROR_FILE_BAD_STATUS, Error::FileBadStatus },
+        file_close_failed = { sgx_status_t::SGX_ERROR_FILE_CLOSE_FAILED, Error::FileCloseFailed },
+        unsupported_att_key_id = { sgx_status_t::SGX_ERROR_UNSUPPORTED_ATT_KEY_ID, Error::UnsupportedAttKeyId },
+        platform_cert_unavailable = { sgx_status_t::SGX_ERROR_PLATFORM_CERT_UNAVAILABLE, Error::PlatformCertUnavailable },
+        interrupted = { sgx_status_t::SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED, Error::EnclaveCreateInterrupted },
     )]
     fn from_sgx_to_error(sgx_status: sgx_status_t, expected: Error) {
-        let error: Error = sgx_status.into();
-        assert_eq!(error, expected);
+        assert_eq!(
+            Error::try_from(sgx_status).expect("Could not convert SGX Status to an error"),
+            expected
+        );
     }
 
     #[test]
     fn unknown_sgx_error_maps_to_unexpected() {
         let unknown = sgx_status_t(0x8000);
-        let error: Error = unknown.into();
-        assert_eq!(error, Error::Unexpected);
+        assert_eq!(
+            Error::try_from(unknown).expect("Could not parse an unknown SGX Status"),
+            Error::Unexpected
+        );
+    }
+
+    #[test]
+    fn success_is_not_an_error() {
+        assert!(Error::try_from(sgx_status_t::SGX_SUCCESS).is_err())
     }
 }

--- a/core/types/src/error.rs
+++ b/core/types/src/error.rs
@@ -4,7 +4,7 @@
 
 use core::result::Result as CoreResult;
 use mc_sgx_core_sys_types::sgx_status_t;
-use mc_sgx_util::ResultFrom;
+use mc_sgx_util::{ResultFrom, ResultInto};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -348,6 +348,7 @@ impl TryFrom<sgx_status_t> for Error {
 }
 
 impl ResultFrom<sgx_status_t> for Error {}
+impl ResultInto<Error> for sgx_status_t {}
 
 #[cfg(test)]
 mod test {

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -13,7 +13,7 @@ mod svn;
 
 pub use crate::{
     attributes::{Attributes, MiscellaneousAttribute, MiscellaneousSelect},
-    error::{Error, FfiError},
+    error::{Error, FfiError, Result},
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},
     svn::{ConfigSvn, CpuSvn, IsvSvn},
 };

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mc-sgx-util"
+# When updating version, update the deps.rs link in README.md
+version = "0.1.0"
+authors = ["MobileCoin"]
+categories = ["api-bindings", "hardware-support"]
+description = "Rust wrapper for SGX capabilities types."
+edition = "2021"
+keywords = ["ffi", "sgx"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/mobilecoinfoundation/sgx"
+rust-version = "1.62.1"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -3,10 +3,10 @@ name = "mc-sgx-util"
 # When updating version, update the deps.rs link in README.md
 version = "0.1.0"
 authors = ["MobileCoin"]
-categories = ["api-bindings", "hardware-support"]
-description = "Rust wrapper for SGX capabilities types."
+categories = ["no-std"]
+description = "Utilities shared by SGX libraries"
 edition = "2021"
-keywords = ["ffi", "sgx"]
+keywords = ["ffi", "no-std", "sgx"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,21 @@
+# MobileCoin SGX: Utilities
+
+[![Project Chat][chat-image]][chat-link]<!--
+-->![License][license-image]<!--
+-->![Target][target-image]<!--
+-->[![Crates.io][crate-image]][crate-link]<!--
+-->[![Docs Status][docs-image]][docs-link]<!--
+-->[![Dependency Status][deps-image]][deps-link]
+
+Small utilities and helpers that are useful to have in a central place.
+
+[chat-image]: https://img.shields.io/discord/844353360348971068?style=flat-square
+[chat-link]: https://mobilecoin.chat
+[license-image]: https://img.shields.io/crates/l/mc-sgx-util?style=flat-square
+[target-image]: https://img.shields.io/badge/target-any-brightgreen?style=flat-square
+[crate-image]: https://img.shields.io/crates/v/mc-sgx-util.svg?style=flat-square
+[crate-link]: https://crates.io/crates/mc-sgx-util
+[docs-image]: https://img.shields.io/docsrs/mc-sgx-util?style=flat-square
+[docs-link]: https://docs.rs/crate/mc-sgx-util
+[deps-image]: https://deps.rs/crate/mc-sgx-util/0.1.0/status.svg?style=flat-square
+[deps-link]: https://deps.rs/crate/mc-sgx-util/0.1.0

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+#![doc = include_str!("../README.md")]
+#![no_std]
+#![deny(missing_docs, missing_debug_implementations, unsafe_code)]
+
+/// A trait to add to an error type which can be constructed from an underlying
+/// "status" type which contains both success and failure codes.
+///
+/// The goal is to be able to convert a unified status type into a `Result<T,
+/// Error>` type.
+///
+/// # Examples
+///
+/// ```rust
+/// use mc_sgx_util::ResultFrom;
+///
+/// /// An example FFI type
+/// #[allow(non_camel_case_types)]
+/// pub struct a_status_t(u32);
+///
+/// impl a_status_t {
+///     const SUCCESS: a_status_t = a_status_t(0);
+///     const FAIL: a_status_t = a_status_t(1);
+/// }
+///
+/// /// An example rusty enum wrapper for a_status_t
+/// pub enum AnError {
+///     Stuff,
+///     Unknown
+/// }
+///
+/// impl TryFrom<a_status_t> for AnError {
+///     type Error = ();
+///
+///     fn try_from(value: a_status_t) -> Result<Self, ()> {
+///         match value {
+///             a_status_t::SUCCESS => Err(()),
+///             a_status_t::FAIL => Ok(AnError::Stuff),
+///             _ => Ok(AnError::Unknown)
+///         }
+///     }
+/// }
+///
+/// // Pick up the default implementation of [`ResultFrom`]
+/// impl ResultFrom<a_status_t> for AnError {}
+///
+/// let status = a_status_t::SUCCESS;
+/// assert_eq!(Ok(()), AnError::result_from(status));
+///
+/// let status = a_status_t::FAIL;
+/// assert_eq!(Err(AnError::Stuff), AnError::result_from(status));
+/// ```
+pub trait ResultFrom<ST>: TryFrom<ST> {
+    /// Flips the result of a `TryFrom`.
+    fn result_from(status: ST) -> Result<<Self as TryFrom<ST>>::Error, Self> {
+        match Self::try_from(status) {
+            Ok(err) => Err(err),
+            Err(success_val) => Ok(success_val),
+        }
+    }
+}
+
+/// An inverse of the [`ResultFrom`] trait, which is attached to the status
+/// type.
+///
+/// As with [`TryInto`](core::convert::TryInto), this trait is not intended to
+/// be implemented manually, but instead should be added to an FFI type via
+/// blanket implementation attached to it's derivative wrapper type.
+///
+/// That is, users should not attach this to a bindgen-generated status type,
+/// they should attach [`ResultFrom`] to the intended error wrapper associated
+/// with it, and they will get this for free.
+pub trait ResultInto<T: TryFrom<Self>>: Sized {
+    /// Flips the result of T::TryFrom<Self>.
+    fn into_result(self) -> Result<<T as TryFrom<Self>>::Error, T> {
+        match T::try_from(self) {
+            Ok(err) => Err(err),
+            Err(success_val) => Ok(success_val),
+        }
+    }
+}
+
+/// This blanket implementation exists to automatically add this to any FFI type
+/// which has an inverse [`ResultFrom`] implementation.
+impl<T, ST> ResultInto<T> for ST where T: ResultFrom<ST> {}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -52,8 +52,6 @@
 ///
 /// let status = a_status_t::FAIL;
 /// assert_eq!(Err(AnError::Stuff), AnError::result_from(status));
-///
-/// assert!(false);
 /// ```
 pub trait ResultFrom<ST>: TryFrom<ST> {
     /// Flips the result of a `TryFrom`.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -74,7 +74,7 @@ pub trait ResultFrom<ST>: TryFrom<ST> {
 /// // Pick up the default implementation of [`ResultInto`]
 /// impl ResultInto<AnError> for a_status_t {}
 /// ```
-///
+/// 
 /// That is, users should not attach this to a bindgen-generated status type,
 /// they should attach [`ResultFrom`] to the intended error wrapper associated
 /// with it, and they will get this for free.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -70,7 +70,7 @@ pub trait ResultFrom<ST>: TryFrom<ST> {
 /// be implemented manually, but instead should be added to an FFI type via
 /// explicit impl block attached to it's derivative wrapper type.
 ///
-/// ```rust
+/// ```rust,ignore
 /// // Pick up the default implementation of [`ResultInto`]
 /// impl ResultInto<AnError> for a_status_t {}
 /// ```

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -68,7 +68,12 @@ pub trait ResultFrom<ST>: TryFrom<ST> {
 ///
 /// As with [`TryInto`](core::convert::TryInto), this trait is not intended to
 /// be implemented manually, but instead should be added to an FFI type via
-/// blanket implementation attached to it's derivative wrapper type.
+/// explicit impl block attached to it's derivative wrapper type.
+///
+/// rust```
+/// // Pick up the default implementation of [`ResultInto`]
+/// impl ResultInto<AnError> for a_status_t {}
+/// ```
 ///
 /// That is, users should not attach this to a bindgen-generated status type,
 /// they should attach [`ResultFrom`] to the intended error wrapper associated

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -17,6 +17,7 @@
 ///
 /// /// An example FFI type
 /// #[allow(non_camel_case_types)]
+/// #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 /// pub struct a_status_t(u32);
 ///
 /// impl a_status_t {
@@ -25,6 +26,7 @@
 /// }
 ///
 /// /// An example rusty enum wrapper for a_status_t
+/// #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 /// pub enum AnError {
 ///     Stuff,
 ///     Unknown
@@ -50,6 +52,8 @@
 ///
 /// let status = a_status_t::FAIL;
 /// assert_eq!(Err(AnError::Stuff), AnError::result_from(status));
+///
+/// assert!(false);
 /// ```
 pub trait ResultFrom<ST>: TryFrom<ST> {
     /// Flips the result of a `TryFrom`.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -70,11 +70,11 @@ pub trait ResultFrom<ST>: TryFrom<ST> {
 /// be implemented manually, but instead should be added to an FFI type via
 /// explicit impl block attached to it's derivative wrapper type.
 ///
-/// rust```
+/// ```rust
 /// // Pick up the default implementation of [`ResultInto`]
 /// impl ResultInto<AnError> for a_status_t {}
 /// ```
-/// 
+///
 /// That is, users should not attach this to a bindgen-generated status type,
 /// they should attach [`ResultFrom`] to the intended error wrapper associated
 /// with it, and they will get this for free.

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -82,7 +82,3 @@ pub trait ResultInto<T: TryFrom<Self>>: Sized {
         }
     }
 }
-
-/// This blanket implementation exists to automatically add this to any FFI type
-/// which has an inverse [`ResultFrom`] implementation.
-impl<T, ST> ResultInto<T> for ST where T: ResultFrom<ST> {}


### PR DESCRIPTION
Create a new set of traits, ResultFrom and ResultInto to simplify the way status types in the SDK are converted to result types (with errors) in idiomatic rust.
