### PR TITLE
Update Changelog and versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `mc-sgx-core-types`: Idiomatic Rust Types for SGX primitives
+- `mc-sgx-core-types`: Idiomatic Rust for SGX primitives
+- `mc-sgx-capable`: Idiomatic Rust bindings for the `sgx_capable` library
+- `mc-sgx-capable-types`: Idiomatic Rust types for the `sgx_capable` library
 - `mc-sgx-tservice-types`: Idiomatic Rust Types for the `sgx_tservice` library
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-capable"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "mc-sgx-capable-sys",
  "mc-sgx-capable-sys-types",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-capable-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-capable-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-capable-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-sgx-capable-sys-types",
@@ -376,14 +376,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-build"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
 ]
 
 [[package]]
 name = "mc-sgx-core-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-core-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bitflags",
  "displaydoc",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-ql-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-ql-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-quoteverify-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-quoteverify-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-quoteverify-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "mc-sgx-core-types",
  "mc-sgx-dcap-quoteverify-sys-types",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "mc-sgx-core-build",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-dcap-tvl-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tcrypto-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tcrypto-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-trts-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tservice-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tservice-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tstdc-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tstdc-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-urts"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "mc-sgx-core-sys-types",
  "mc-sgx-urts-sys",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-urts-sys"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-urts-sys-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-util"
-version = "0.1.0"
+version = "0.2.0-pre0"
 
 [[package]]
 name = "memchr"
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "test_enclave"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
  "cargo-emit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-tservice-types"
-version = "0.1.0"
+version = "0.2.0-pre0"
 dependencies = [
  "mc-sgx-core-types",
  "mc-sgx-tservice-sys-types",

--- a/capable/Cargo.toml
+++ b/capable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-capable"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 edition = "2021"
 authors = ["MobileCoin"]
 rust-version = "1.62.1"
@@ -14,11 +14,11 @@ categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
 
 [dependencies]
-mc-sgx-capable-sys = { path = "sys", version = "=0.1.0" }
-mc-sgx-capable-sys-types = { path = "sys/types", version = "=0.1.0" }
-mc-sgx-capable-types = { path = "types", version = "=0.1.0" }
-mc-sgx-core-types = { path = "../core/types", version = "=0.1.0" }
-mc-sgx-util = { path = "../util", version = "=0.1.0" }
+mc-sgx-capable-sys = { path = "sys", version = "=0.2.0-pre0" }
+mc-sgx-capable-sys-types = { path = "sys/types", version = "=0.2.0-pre0" }
+mc-sgx-capable-types = { path = "types", version = "=0.2.0-pre0" }
+mc-sgx-core-types = { path = "../core/types", version = "=0.2.0-pre0" }
+mc-sgx-util = { path = "../util", version = "=0.2.0-pre0" }
 
 [dev-dependencies]
 yare = "1.0.1"

--- a/capable/sys/Cargo.toml
+++ b/capable/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-capable-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support"]
 description = "FFI linkage for the `sgx_capable` library."
@@ -16,8 +16,8 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-capable-sys-types = { path = "types", version = "=0.1.0" }
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
+mc-sgx-capable-sys-types = { path = "types", version = "=0.2.0-pre0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/capable/sys/Cargo.toml
+++ b/capable/sys/Cargo.toml
@@ -22,4 +22,4 @@ mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.2.0-pre0" }

--- a/capable/sys/types/Cargo.toml
+++ b/capable/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-capable-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions used by the `sgx_capable` library."

--- a/capable/sys/types/Cargo.toml
+++ b/capable/sys/types/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/capable/types/Cargo.toml
+++ b/capable/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-capable-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["api-bindings", "hardware-support"]
 description = "Rust wrapper for SGX capabilities types."
@@ -21,9 +21,9 @@ serde = [
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
-mc-sgx-capable-sys-types = { path = "../sys/types", version = "=0.1.0" }
-mc-sgx-core-types = { path = "../../core/types", version = "=0.1.0" }
-mc-sgx-util = { path = "../../util", version = "=0.1.0" }
+mc-sgx-capable-sys-types = { path = "../sys/types", version = "=0.2.0-pre0" }
+mc-sgx-core-types = { path = "../../core/types", version = "=0.2.0-pre0" }
+mc-sgx-util = { path = "../../util", version = "=0.2.0-pre0" }
 serde = { version = "1.0.144", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-core-build"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["development-tools"]
 description = "Build Helpers for SGX FFI Crates"

--- a/core/sys/types/Cargo.toml
+++ b/core/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-core-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions used by SGX libraries."

--- a/core/sys/types/Cargo.toml
+++ b/core/sys/types/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../build", version = "=0.2.0-pre0" }

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-core-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["api-bindings", "hardware-support"]
 description = "Rust wrapper for common SGX types."

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -22,8 +22,8 @@ alloc = []
 [dependencies]
 bitflags = "1.3.2"
 displaydoc = { version = "0.2.3", default-features = false }
-mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.1.0" }
-mc-sgx-util = { path = "../../util", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.2.0-pre0" }
+mc-sgx-util = { path = "../../util", version = "=0.2.0-pre0" }
 rand_core = { version = "0.6.3", default-features = false }
 serde = { version = "1.0.144", default-features = false, features = ["derive"], optional = true }
 

--- a/dcap/ql/sys/Cargo.toml
+++ b/dcap/ql/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-ql-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support"]
 description = "FFI linkage for the `sgx_dcap_ql` library."
@@ -17,9 +17,9 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
-mc-sgx-dcap-ql-sys-types = { path = "types", version = "=0.1.0" }
-mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-ql-sys-types = { path = "types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap/ql/sys/Cargo.toml
+++ b/dcap/ql/sys/Cargo.toml
@@ -24,4 +24,4 @@ mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/ql/sys/types/Cargo.toml
+++ b/dcap/ql/sys/types/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/ql/sys/types/Cargo.toml
+++ b/dcap/ql/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-ql-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions for the `sgx_dcap_ql` library."

--- a/dcap/quoteverify/sys/Cargo.toml
+++ b/dcap/quoteverify/sys/Cargo.toml
@@ -23,4 +23,4 @@ mc-sgx-dcap-sys-types = { path = "../../../dcap/sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/quoteverify/sys/Cargo.toml
+++ b/dcap/quoteverify/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-quoteverify-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support"]
 description = "FFI linkage for the `sgx_dcap_quoteverify` library."
@@ -17,8 +17,8 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-dcap-quoteverify-sys-types = { path = "types", version = "=0.1.0" }
-mc-sgx-dcap-sys-types = { path = "../../../dcap/sys/types", version = "=0.1.0" }
+mc-sgx-dcap-quoteverify-sys-types = { path = "types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-sys-types = { path = "../../../dcap/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap/quoteverify/sys/types/Cargo.toml
+++ b/dcap/quoteverify/sys/types/Cargo.toml
@@ -21,4 +21,4 @@ mc-sgx-dcap-sys-types = { path = "../../../sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/quoteverify/sys/types/Cargo.toml
+++ b/dcap/quoteverify/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-quoteverify-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions used by the `sgx_dcap_quoteverify` library."
@@ -16,7 +16,7 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-dcap-sys-types = { path = "../../../sys/types", version = "=0.1.0" }
+mc-sgx-dcap-sys-types = { path = "../../../sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap/quoteverify/types/Cargo.toml
+++ b/dcap/quoteverify/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-quoteverify-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["api-bindings", "hardware-support"]
 description = "Rust wrapper for `dcap_quoteverify` types."
@@ -13,8 +13,8 @@ repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-core-types = { path = "../../../core/types", version = "=0.1.0" }
-mc-sgx-dcap-quoteverify-sys-types = { path = "../sys/types", version = "=0.1.0" }
+mc-sgx-core-types = { path = "../../../core/types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-quoteverify-sys-types = { path = "../sys/types", version = "=0.2.0-pre0" }
 
 [dev-dependencies]
 yare = "1.0.2"

--- a/dcap/sys/types/Cargo.toml
+++ b/dcap/sys/types/Cargo.toml
@@ -20,4 +20,4 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 
 [build-dependencies]
 bindgen = "0.60.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/sys/types/Cargo.toml
+++ b/dcap/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions for the SGX DCAP libraries."
@@ -16,7 +16,7 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/dcap/tvl/sys/Cargo.toml
+++ b/dcap/tvl/sys/Cargo.toml
@@ -26,4 +26,4 @@ mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/dcap/tvl/sys/Cargo.toml
+++ b/dcap/tvl/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-dcap-tvl-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI bindings for `sgx_dcap_tvl`."
@@ -19,9 +19,9 @@ test = false
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
-mc-sgx-dcap-quoteverify-sys-types = { path = "../../quoteverify/sys/types", version = "=0.1.0" }
-mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-quoteverify-sys-types = { path = "../../quoteverify/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-dcap-sys-types = { path = "../../sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/tcrypto/sys/Cargo.toml
+++ b/tcrypto/sys/Cargo.toml
@@ -26,4 +26,4 @@ sha2 = "0.10.3"
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.2.0-pre0" }

--- a/tcrypto/sys/Cargo.toml
+++ b/tcrypto/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tcrypto-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI bindings for `sgx_tcrypto`."
@@ -17,8 +17,8 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
-mc-sgx-tcrypto-sys-types = { path = "types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-tcrypto-sys-types = { path = "types", version = "=0.2.0-pre0" }
 
 [dev-dependencies]
 sha2 = "0.10.3"

--- a/tcrypto/sys/types/Cargo.toml
+++ b/tcrypto/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tcrypto-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions used by `sgx_tcrypto`."

--- a/tcrypto/sys/types/Cargo.toml
+++ b/tcrypto/sys/types/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/test_enclave/Cargo.toml
+++ b/test_enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_enclave"
-version = "0.1.0"
+version = "0.2.0-pre0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/test_enclave/Cargo.toml
+++ b/test_enclave/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-mc-sgx-urts-sys-types = { path = "../urts/sys/types", version = "=0.1.0" }
-mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.1.0" }
+mc-sgx-urts-sys-types = { path = "../urts/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.2.0-pre0" }
 
 [features]
 default = []
@@ -16,7 +16,6 @@ sim = []
 cargo-emit = "0.2.1"
 cc = "1.0.73"
 bindgen = "0.60.1"
+mc-sgx-core-build = { path = "../core/build", version = "=0.2.0-pre0" }
 rsa = "0.6.1"
 rand = "0.8.5"
-
-mc-sgx-core-build = { path = "../core/build", version = "=0.1.0" }

--- a/trts/sys/Cargo.toml
+++ b/trts/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-trts-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI bindings for `sgx_trts`."
@@ -23,7 +23,7 @@ default = []
 sim = []
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/trts/sys/Cargo.toml
+++ b/trts/sys/Cargo.toml
@@ -28,4 +28,4 @@ mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.2.0-pre0" }

--- a/tservice/sys/Cargo.toml
+++ b/tservice/sys/Cargo.toml
@@ -23,4 +23,4 @@ mc-sgx-tservice-sys-types = { path = "types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.2.0-pre0" }

--- a/tservice/sys/Cargo.toml
+++ b/tservice/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tservice-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI bindings for `sgx_tservice`."
@@ -17,8 +17,8 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
-mc-sgx-tservice-sys-types = { path = "types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-tservice-sys-types = { path = "types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/tservice/sys/types/Cargo.toml
+++ b/tservice/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tservice-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI type definitions for `sgx_tservice`."
@@ -16,8 +16,8 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
-mc-sgx-tcrypto-sys-types = { path = "../../../tcrypto/sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-tcrypto-sys-types = { path = "../../../tcrypto/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/tservice/sys/types/Cargo.toml
+++ b/tservice/sys/types/Cargo.toml
@@ -22,4 +22,4 @@ mc-sgx-tcrypto-sys-types = { path = "../../../tcrypto/sys/types", version = "=0.
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/tservice/types/Cargo.toml
+++ b/tservice/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tservice-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["api-bindings", "hardware-support"]
 description = "Rust wrapper for SGX trusted service types."
@@ -17,5 +17,5 @@ default = []
 serde = [ "mc-sgx-core-types/serde" ]
 
 [dependencies]
-mc-sgx-core-types = { path = "../../core/types", version = "=0.1.0" }
-mc-sgx-tservice-sys-types = { path = "../sys/types", version = "=0.1.0" }
+mc-sgx-core-types = { path = "../../core/types", version = "=0.2.0-pre0" }
+mc-sgx-tservice-sys-types = { path = "../sys/types", version = "=0.2.0-pre0" }

--- a/tstdc/sys/Cargo.toml
+++ b/tstdc/sys/Cargo.toml
@@ -25,4 +25,4 @@ mc-sgx-tstdc-sys-types = { path = "types", version = "0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "0.2.0-pre0" }

--- a/tstdc/sys/Cargo.toml
+++ b/tstdc/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tstdc-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI bindings for `sgx_tstdc`."
@@ -19,8 +19,8 @@ test = false
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "0.1.0" }
-mc-sgx-tstdc-sys-types = { path = "types", version = "0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "0.2.0-pre0" }
+mc-sgx-tstdc-sys-types = { path = "types", version = "0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/tstdc/sys/types/Cargo.toml
+++ b/tstdc/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-tstdc-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI types for `sgx_tstdc`."

--- a/tstdc/sys/types/Cargo.toml
+++ b/tstdc/sys/types/Cargo.toml
@@ -18,4 +18,4 @@ doctest = false
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/urts/Cargo.toml
+++ b/urts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-urts"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["api-bindings", "hardware-support"]
 description = "Rust wrapper for `sgx_urts`."
@@ -13,13 +13,13 @@ repository = "https://github.com/mobilecoinfoundation/sgx"
 rust-version = "1.62.1"
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.1.0" }
-mc-sgx-urts-sys = { path = "sys", version = "=0.1.0" }
-mc-sgx-urts-sys-types = { path = "sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-urts-sys = { path = "sys", version = "=0.2.0-pre0" }
+mc-sgx-urts-sys-types = { path = "sys/types", version = "=0.2.0-pre0" }
 
 [features]
 sim = ["mc-sgx-urts-sys/sim", "test_enclave/sim"]
 default = []
 
 [dev-dependencies]
-test_enclave = { path = "../test_enclave", version = "=0.1.0" }
+test_enclave = { path = "../test_enclave", version = "=0.2.0-pre0" }

--- a/urts/sys/Cargo.toml
+++ b/urts/sys/Cargo.toml
@@ -27,4 +27,4 @@ mc-sgx-urts-sys-types = { path = "types", version = "=0.1.0" }
 [build-dependencies]
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
-mc-sgx-core-build = { path = "../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../core/build", version = "=0.2.0-pre0" }

--- a/urts/sys/Cargo.toml
+++ b/urts/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-urts-sys"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support"]
 description = "FFI bindings for `sgx_urts`."
@@ -21,8 +21,8 @@ sim = []
 default = []
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.1.0" }
-mc-sgx-urts-sys-types = { path = "types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.2.0-pre0" }
+mc-sgx-urts-sys-types = { path = "types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/urts/sys/types/Cargo.toml
+++ b/urts/sys/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-urts-sys-types"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["external-ffi-bindings", "hardware-support", "no-std"]
 description = "FFI types for `sgx_urts`."
@@ -16,7 +16,7 @@ rust-version = "1.62.1"
 doctest = false
 
 [dependencies]
-mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
+mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.2.0-pre0" }
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/urts/sys/types/Cargo.toml
+++ b/urts/sys/types/Cargo.toml
@@ -22,4 +22,4 @@ mc-sgx-core-sys-types = { path = "../../../core/sys/types", version = "=0.1.0" }
 bindgen = "0.60.1"
 cargo-emit = "0.2.1"
 
-mc-sgx-core-build = { path = "../../../core/build", version = "=0.1.0" }
+mc-sgx-core-build = { path = "../../../core/build", version = "=0.2.0-pre0" }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-sgx-util"
 # When updating version, update the deps.rs link in README.md
-version = "0.1.0"
+version = "0.2.0-pre0"
 authors = ["MobileCoin"]
 categories = ["no-std"]
 description = "Utilities shared by SGX libraries"


### PR DESCRIPTION
Bump all versions to 0.2.0-pre0, update Changelog for new crates.
