### PR TITLE
Add `ExtendedAttestationKeyId` rust wrapper

### DIFF
--- a/core/types/src/attestation_key.rs
+++ b/core/types/src/attestation_key.rs
@@ -176,7 +176,7 @@ pub struct ExtendedAttestationKeyId(sgx_att_key_id_ext_t);
 
 impl ExtendedAttestationKeyId {
     // The base attestation key
-    pub fn base_attestation_key(&self) -> QuoteLibAttestationKeyId {
+    pub fn base_key_id(&self) -> QuoteLibAttestationKeyId {
         self.0.base.into()
     }
 
@@ -214,10 +214,7 @@ mod test {
     #[test]
     fn default_extended_attestation_key_id() {
         let key = ExtendedAttestationKeyId::default();
-        assert_eq!(
-            key.base_attestation_key(),
-            QuoteLibAttestationKeyId::default()
-        );
+        assert_eq!(key.base_key_id(), QuoteLibAttestationKeyId::default());
         assert_eq!(key.service_provider_id(), ServiceProviderId([0u8; 16]));
         assert_eq!(key.key_type(), 0);
     }
@@ -233,7 +230,7 @@ mod test {
             reserved: [3u8; 80],
         };
         let key: ExtendedAttestationKeyId = sgx_key.into();
-        assert_eq!(key.base_attestation_key(), base_key);
+        assert_eq!(key.base_key_id(), base_key);
         assert_eq!(key.service_provider_id(), ServiceProviderId([10u8; 16]));
         assert_eq!(key.key_type(), 5);
     }

--- a/core/types/src/attestation_key.rs
+++ b/core/types/src/attestation_key.rs
@@ -1,0 +1,271 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Attestation Key types
+
+use crate::{
+    attestation_key::QuoteSignature::{Linkable, UnLinkable},
+    new_type_accessors_impls,
+    report::{ExtendedProductId, FamilyId},
+    ConfigId, FfiError,
+};
+use mc_sgx_core_sys_types::{sgx_att_key_id_ext_t, sgx_ql_att_key_id_t, sgx_quote_sign_type_t};
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum MrSignerKeyHash {
+    Sha256([u8; 32]),
+    Sha384([u8; 48]),
+}
+
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct AlgorithmId(u32);
+
+new_type_accessors_impls! {
+    AlgorithmId, u32;
+}
+
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Version(u16);
+
+new_type_accessors_impls! {
+    Version, u16;
+}
+
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Id(u16);
+
+new_type_accessors_impls! {
+    Id, u16;
+}
+
+/// The type of quote signature.  Only valid for EPID quotes.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[non_exhaustive]
+#[repr(u16)]
+enum QuoteSignature {
+    UnLinkable,
+    Linkable,
+}
+
+impl From<sgx_quote_sign_type_t> for QuoteSignature {
+    fn from(sign_type: sgx_quote_sign_type_t) -> QuoteSignature {
+        match sign_type {
+            // Per the header `sgx_quote.h` and
+            // https://download.01.org/intel-sgx/sgx-linux/2.17.1/docs/Intel_SGX_Developer_Reference_Linux_2.17.1_Open_Source.pdf
+            // the `sgx_att_key_id_ext_t::att_key_type` is only valid for EPID
+            // quotes it will be 0 otherwise, which also happens to map to
+            // SGX_UNLINKABLE_SIGNATURE.
+            sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE => UnLinkable,
+            sgx_quote_sign_type_t::SGX_LINKABLE_SIGNATURE => Linkable,
+            v => panic!("Got unknown 'sgx_quote_sign_type_t': {:?}", v),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct QuoteLibAttestationKeyId(sgx_ql_att_key_id_t);
+
+impl QuoteLibAttestationKeyId {
+    /// The ID
+    pub fn id(&self) -> Id {
+        self.0.id.into()
+    }
+
+    /// The key version
+    pub fn version(&self) -> Version {
+        self.0.version.into()
+    }
+
+    /// The hash of the MRSIGNER key.
+    ///
+    /// # Errors
+    /// When the length of the hash is not a valid length for a hash,
+    /// [`sgx_ql_att_key_id_t::mrsigner_length`].
+    pub fn mr_signer_key_hash(&self) -> Result<MrSignerKeyHash, FfiError> {
+        match self.0.mrsigner_length {
+            32 => {
+                let mut array: [u8; 32] = [0u8; 32];
+                array.copy_from_slice(&self.0.mrsigner[..32]);
+                Ok(MrSignerKeyHash::Sha256(array))
+            }
+            48 => {
+                let mut array: [u8; 48] = [0u8; 48];
+                array.copy_from_slice(&self.0.mrsigner[..48]);
+                Ok(MrSignerKeyHash::Sha384(array))
+            }
+            _ => Err(FfiError::InvalidInputLength),
+        }
+    }
+
+    /// The product ID
+    pub fn product_id(&self) -> ExtendedProductId {
+        self.0.extended_prod_id.into()
+    }
+
+    /// The config ID
+    pub fn config_id(&self) -> ConfigId {
+        self.0.config_id.into()
+    }
+
+    /// The family ID
+    pub fn family_id(&self) -> FamilyId {
+        self.0.family_id.into()
+    }
+
+    /// The algorithm ID
+    pub fn algorithm_id(&self) -> AlgorithmId {
+        self.0.algorithm_id.into()
+    }
+}
+
+new_type_accessors_impls! {
+    QuoteLibAttestationKeyId, sgx_ql_att_key_id_t;
+}
+
+impl Default for QuoteLibAttestationKeyId {
+    fn default() -> Self {
+        Self(sgx_ql_att_key_id_t {
+            id: 0,
+            version: 0,
+            mrsigner_length: 32,
+            mrsigner: [0u8; 48],
+            prod_id: 0,
+            extended_prod_id: [0u8; 16],
+            config_id: [0u8; 64],
+            family_id: [0u8; 16],
+            algorithm_id: 0,
+        })
+    }
+}
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct ServiceProviderId([u8; 16]);
+
+new_type_accessors_impls! {
+    ServiceProviderId, [u8; 16];
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct ExtendedAttestationKeyId(sgx_att_key_id_ext_t);
+
+impl ExtendedAttestationKeyId {
+    // The base attestation key
+    pub fn base_attestation_key(&self) -> QuoteLibAttestationKeyId {
+        self.0.base.into()
+    }
+
+    // Service provider id
+    pub fn service_provider_id(&self) -> ServiceProviderId {
+        self.0.spid.into()
+    }
+
+    // Key type
+    pub fn key_type(&self) -> u16 {
+        self.0.att_key_type
+    }
+}
+
+new_type_accessors_impls! {
+    ExtendedAttestationKeyId, sgx_att_key_id_ext_t;
+}
+
+impl Default for ExtendedAttestationKeyId {
+    fn default() -> Self {
+        Self(sgx_att_key_id_ext_t {
+            base: QuoteLibAttestationKeyId::default().into(),
+            spid: [0u8; 16],
+            att_key_type: 0,
+            reserved: [0u8; 80],
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use yare::parameterized;
+
+    #[test]
+    fn default_extended_attestation_key_id() {
+        let key = ExtendedAttestationKeyId::default();
+        assert_eq!(
+            key.base_attestation_key(),
+            QuoteLibAttestationKeyId::default()
+        );
+        assert_eq!(key.service_provider_id(), ServiceProviderId([0u8; 16]));
+        assert_eq!(key.key_type(), 0);
+    }
+
+    #[test]
+    fn extended_attestation_key_id_from_sgx() {
+        let mut base_key = QuoteLibAttestationKeyId::default();
+        base_key.0.id = 20;
+        let sgx_key = sgx_att_key_id_ext_t {
+            base: base_key.clone().into(),
+            spid: [10u8; 16],
+            att_key_type: 5,
+            reserved: [3u8; 80],
+        };
+        let key: ExtendedAttestationKeyId = sgx_key.into();
+        assert_eq!(key.base_attestation_key(), base_key);
+        assert_eq!(key.service_provider_id(), ServiceProviderId([10u8; 16]));
+        assert_eq!(key.key_type(), 5);
+    }
+
+    #[test]
+    fn default_quote_lib_attestation_key_id() {
+        let key = QuoteLibAttestationKeyId::default();
+        assert_eq!(key.id(), Id::default());
+        assert_eq!(key.version(), Version::default());
+        assert_eq!(
+            key.mr_signer_key_hash(),
+            Ok(MrSignerKeyHash::Sha256([0u8; 32]))
+        );
+        assert_eq!(key.product_id(), ExtendedProductId::default());
+        assert_eq!(key.config_id(), ConfigId::default());
+        assert_eq!(key.family_id(), FamilyId::default());
+        assert_eq!(key.algorithm_id(), AlgorithmId::default());
+    }
+
+    #[test]
+    fn quote_lib_attestation_key_id_from_sgx() {
+        let sgx_key = sgx_ql_att_key_id_t {
+            id: 1,
+            version: 2,
+            mrsigner_length: 48,
+            mrsigner: [4u8; 48],
+            prod_id: 5,
+            extended_prod_id: [6u8; 16],
+            config_id: [7u8; 64],
+            family_id: [8u8; 16],
+            algorithm_id: 9,
+        };
+        let key: QuoteLibAttestationKeyId = sgx_key.into();
+        assert_eq!(key.id(), Id(1));
+        assert_eq!(key.version(), Version(2));
+        assert_eq!(
+            key.mr_signer_key_hash(),
+            Ok(MrSignerKeyHash::Sha384([4u8; 48]))
+        );
+        assert_eq!(key.product_id(), ExtendedProductId::from([6u8; 16]));
+        assert_eq!(key.config_id(), ConfigId::from([7u8; 64]));
+        assert_eq!(key.family_id(), FamilyId::from([8u8; 16]));
+        assert_eq!(key.algorithm_id(), AlgorithmId::from(9));
+    }
+
+    #[parameterized(
+    nothing = {0},
+    too_small_256 = {31},
+    too_large_256 = {33},
+    too_small_384 = {47},
+    too_large_384 = {49},
+    )]
+    fn invalid_mr_signer_length(length: u16) {
+        let mut key = QuoteLibAttestationKeyId::default();
+        key.0.mrsigner_length = length;
+        assert_eq!(key.mr_signer_key_hash(), Err(FfiError::InvalidInputLength));
+    }
+}

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -5,6 +5,7 @@
 
 extern crate alloc;
 
+mod attestation_key;
 mod attributes;
 mod config_id;
 mod error;
@@ -16,6 +17,7 @@ mod svn;
 mod target_info;
 
 pub use crate::{
+    attestation_key::{ExtendedAttestationKeyId, QuoteLibAttestationKeyId},
     attributes::{Attributes, MiscellaneousAttribute, MiscellaneousSelect},
     config_id::ConfigId,
     error::{Error, FfiError, Result},

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -33,22 +33,22 @@ impl_newtype_for_bytestruct! {
 /// ISV Family ID
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 #[repr(transparent)]
-pub struct IsvFamilyId(sgx_isvfamily_id_t);
+pub struct FamilyId(sgx_isvfamily_id_t);
 
 new_type_accessors_impls! {
-    IsvFamilyId, sgx_isvfamily_id_t;
+    FamilyId, sgx_isvfamily_id_t;
 }
 
-/// ISV Extended Product ID
+/// Extended Product ID
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct IsvExtendedProductId(sgx_isvext_prod_id_t);
+pub struct ExtendedProductId(sgx_isvext_prod_id_t);
 
 new_type_accessors_impls! {
-    IsvExtendedProductId, sgx_isvext_prod_id_t;
+    ExtendedProductId, sgx_isvext_prod_id_t;
 }
 
-impl Default for IsvExtendedProductId {
+impl Default for ExtendedProductId {
     fn default() -> Self {
         Self([0; SGX_ISVEXT_PROD_ID_SIZE])
     }
@@ -80,7 +80,7 @@ impl ReportBody {
     }
 
     /// The ISV extended product id
-    pub fn isv_extended_product_id(&self) -> IsvExtendedProductId {
+    pub fn isv_extended_product_id(&self) -> ExtendedProductId {
         self.0.isv_ext_prod_id.into()
     }
 
@@ -120,7 +120,7 @@ impl ReportBody {
     }
 
     /// The ISV Family ID
-    pub fn isv_family_id(&self) -> IsvFamilyId {
+    pub fn isv_family_id(&self) -> FamilyId {
         self.0.isv_family_id.into()
     }
 
@@ -146,7 +146,7 @@ impl Default for ReportBody {
             cpu_svn: CpuSvn::default().into(),
             misc_select: MiscellaneousSelect::default().into(),
             reserved1: [0u8; SGX_REPORT_BODY_RESERVED1_BYTES],
-            isv_ext_prod_id: IsvExtendedProductId::default().into(),
+            isv_ext_prod_id: ExtendedProductId::default().into(),
             attributes: Attributes::default().into(),
             mr_enclave: MrEnclave::default().into(),
             reserved2: [0u8; SGX_REPORT_BODY_RESERVED2_BYTES],
@@ -157,7 +157,7 @@ impl Default for ReportBody {
             isv_svn: IsvSvn::default().into(),
             config_svn: ConfigSvn::default().into(),
             reserved4: [0u8; SGX_REPORT_BODY_RESERVED4_BYTES],
-            isv_family_id: IsvFamilyId::default().into(),
+            isv_family_id: FamilyId::default().into(),
             report_data: ReportData::default().into(),
         })
     }
@@ -212,10 +212,7 @@ mod test {
         let body = ReportBody::default();
         assert_eq!(body.cpu_svn(), CpuSvn::default());
         assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::default());
-        assert_eq!(
-            body.isv_extended_product_id(),
-            IsvExtendedProductId::default()
-        );
+        assert_eq!(body.isv_extended_product_id(), ExtendedProductId::default());
         assert_eq!(body.attributes(), Attributes::default());
         assert_eq!(
             body.mr_enclave(),
@@ -226,7 +223,7 @@ mod test {
         assert_eq!(body.isv_product_id(), IsvProductId::default());
         assert_eq!(body.isv_svn(), IsvSvn::default());
         assert_eq!(body.config_svn(), ConfigSvn::default());
-        assert_eq!(body.isv_family_id(), IsvFamilyId::default());
+        assert_eq!(body.isv_family_id(), FamilyId::default());
         assert_eq!(body.report_data(), ReportData::default());
     }
 
@@ -259,7 +256,7 @@ mod test {
         assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::new(2));
         assert_eq!(
             body.isv_extended_product_id(),
-            IsvExtendedProductId([4u8; SGX_ISVEXT_PROD_ID_SIZE])
+            ExtendedProductId([4u8; SGX_ISVEXT_PROD_ID_SIZE])
         );
         assert_eq!(
             body.attributes(),
@@ -279,7 +276,7 @@ mod test {
         assert_eq!(body.config_svn(), ConfigSvn::new(14));
         assert_eq!(
             body.isv_family_id(),
-            IsvFamilyId([16u8; SGX_ISV_FAMILY_ID_SIZE])
+            FamilyId([16u8; SGX_ISV_FAMILY_ID_SIZE])
         );
         assert_eq!(
             body.report_data(),


### PR DESCRIPTION
Add the `ExtendedAttestationKeyId` to wrap up the `sgx_att_key_id_ext_t`
in a rust structure.