### PR TITLE
Add `alloc` feature

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --locked --features sim
+          args: --release --locked --features "sim alloc"
   doc:
     runs-on: ubuntu-20.04
     needs:

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 serde = [
     "dep:serde"
 ]
+alloc = []
 
 [dependencies]
 bitflags = "1.3.2"

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -3,6 +3,7 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod attestation_key;

--- a/dcap/quoteverify/types/src/lib.rs
+++ b/dcap/quoteverify/types/src/lib.rs
@@ -3,8 +3,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 
-extern crate alloc;
-
 use mc_sgx_core_types::FfiError;
 use mc_sgx_dcap_quoteverify_sys_types::sgx_qv_path_type_t;
 


### PR DESCRIPTION
The feature `alloc` has been created which is used to enable the usage
of `alloc::` constructs.