### PR TITLE
Add `missing_docs` check to newer crates

### DIFF
--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -5,6 +5,7 @@
 use crate::new_type_accessors_impls;
 use mc_sgx_core_sys_types::{sgx_attributes_t, sgx_misc_attribute_t, sgx_misc_select_t};
 
+/// Attributes of the enclave
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Attributes(sgx_attributes_t);
@@ -23,33 +24,31 @@ impl Attributes {
         self
     }
 
-    /// Set the `transform` for the attributes
+    /// Set the extended features request mask (xfrm)
     ///
     /// # Arguments
     ///
-    /// * `transmform` - The transform to be set to the `xfrm` in the attributes
-    pub fn set_transform(mut self, transform: u64) -> Self {
-        self.0.xfrm = transform;
+    /// * `features_mask` - The mask to be set to the `xfrm` in the attributes
+    pub fn set_extended_features_mask(mut self, features_mask: u64) -> Self {
+        self.0.xfrm = features_mask;
         self
     }
 }
 
+/// Miscellaneous select bits for target enclave. Reserved for future extension.
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 pub struct MiscellaneousSelect(sgx_misc_select_t);
+
 new_type_accessors_impls! {
     MiscellaneousSelect, sgx_misc_select_t;
 }
 
-impl MiscellaneousSelect {
-    pub fn new(select: u32) -> Self {
-        Self(select)
-    }
-}
-
+/// Miscellaneous attributes and select bits for target enclave.
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct MiscellaneousAttribute(sgx_misc_attribute_t);
+
 new_type_accessors_impls! {
     MiscellaneousAttribute, sgx_misc_attribute_t;
 }
@@ -81,7 +80,7 @@ mod test {
     fn attributes_builder(flags: u64, transform: u64) {
         let attributes = Attributes::default()
             .set_flags(flags)
-            .set_transform(transform);
+            .set_extended_features_mask(transform);
         assert_eq!(attributes.0.flags, flags);
         assert_eq!(attributes.0.xfrm, transform);
     }

--- a/core/types/src/key_request.rs
+++ b/core/types/src/key_request.rs
@@ -24,6 +24,8 @@ impl_newtype_for_bytestruct! {
     KeyId, sgx_key_id_t, SGX_KEYID_SIZE, id;
 }
 
+/// Key Name
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 #[non_exhaustive]
 #[repr(u16)]
 pub enum KeyName {
@@ -44,6 +46,7 @@ pub enum KeyName {
 }
 
 bitflags! {
+    /// Policy to use for the key derivation
     pub struct KeyPolicy: u16 {
         /// Derive key using the enclave's ENCLAVE measurement register
         const MRENCLAVE = SGX_KEYPOLICY_MRENCLAVE;
@@ -65,13 +68,17 @@ bitflags! {
     }
 }
 
-#[repr(transparent)]
+/// Key request
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct KeyRequest(sgx_key_request_t);
 new_type_accessors_impls! {
     KeyRequest, sgx_key_request_t;
 }
 
+/// A builder for creating a [`KeyRequest`]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct KeyRequestBuilder(sgx_key_request_t);
 
 impl KeyRequestBuilder {
@@ -215,11 +222,15 @@ mod test {
         let request = KeyRequestBuilder::new(&mut csprng)
             .key_name(KeyName::Provision)
             .key_policy(KeyPolicy::MRENCLAVE | KeyPolicy::NO_ISV_PROD_ID)
-            .isv_svn(&IsvSvn::new(2))
+            .isv_svn(&IsvSvn::from(2))
             .cpu_svn(&CpuSvn::from([3; CpuSvn::SIZE]))
-            .attributes(&Attributes::default().set_flags(4).set_transform(6))
+            .attributes(
+                &Attributes::default()
+                    .set_flags(4)
+                    .set_extended_features_mask(6),
+            )
             .miscellaneous_select(&7.into())
-            .config_svn(&ConfigSvn::new(8))
+            .config_svn(&ConfigSvn::from(8))
             .build();
 
         assert_eq!(request.0.key_name, 1);

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![doc = include_str!("../README.md")]
 #![no_std]
+#![deny(missing_docs, missing_debug_implementations, unsafe_code)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -19,7 +20,7 @@ mod svn;
 mod target_info;
 
 pub use crate::{
-    attestation_key::{ExtendedAttestationKeyId, QuoteLibAttestationKeyId},
+    attestation_key::{AttestationKeyId, ExtendedAttestationKeyId},
     attributes::{Attributes, MiscellaneousAttribute, MiscellaneousSelect},
     config_id::ConfigId,
     error::{Error, FfiError, Result},

--- a/core/types/src/macros.rs
+++ b/core/types/src/macros.rs
@@ -55,6 +55,7 @@ macro_rules! impl_newtype_for_bytestruct {
         }
 
         impl $wrapper {
+            #[doc="Size of the internal array"]
             pub const SIZE: usize = $size;
         }
 

--- a/core/types/src/measurement.rs
+++ b/core/types/src/measurement.rs
@@ -33,7 +33,9 @@ impl_newtype_for_bytestruct! {
 /// enclave-vs-author attestation policy.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Measurement {
+    /// A MRENCLAVE measurement
     MrEnclave(MrEnclave),
+    /// A MRSIGNER measurement
     MrSigner(MrSigner),
 }
 

--- a/core/types/src/quote.rs
+++ b/core/types/src/quote.rs
@@ -241,6 +241,7 @@ mod test {
         bytes.copy_from_slice(alias_bytes);
         bytes
     }
+
     fn base_quote_1() -> sgx_quote_t {
         let mut report_body = sgx_report_body_t::default();
         report_body.misc_select = 18;

--- a/core/types/src/quote.rs
+++ b/core/types/src/quote.rs
@@ -225,11 +225,27 @@ mod test {
     use core::{mem, slice};
     use mc_sgx_core_sys_types::{sgx_quote_t, sgx_report_body_t, sgx_report_t, sgx_target_info_t};
 
-    fn base_quote_1() -> [u8; mem::size_of::<sgx_quote_t>()] {
+    #[allow(unsafe_code)]
+    fn quote_to_bytes(report: sgx_quote_t) -> [u8; mem::size_of::<sgx_quote_t>()] {
+        // SAFETY: This is a test only function. The size of `report` is used
+        // for reinterpretation of `report` into a byte slice. The slice is
+        // copied from prior to the leaving of this function ensuring the raw
+        // pointer is not persisted.
+        let alias_bytes: &[u8] = unsafe {
+            slice::from_raw_parts(
+                &report as *const sgx_quote_t as *const u8,
+                mem::size_of::<sgx_quote_t>(),
+            )
+        };
+        let mut bytes: [u8; mem::size_of::<sgx_quote_t>()] = [0; mem::size_of::<sgx_quote_t>()];
+        bytes.copy_from_slice(alias_bytes);
+        bytes
+    }
+    fn base_quote_1() -> sgx_quote_t {
         let mut report_body = sgx_report_body_t::default();
         report_body.misc_select = 18;
 
-        let quote = sgx_quote_t {
+        sgx_quote_t {
             version: 11,
             sign_type: 0,
             epid_group_id: [13u8; 4],
@@ -240,23 +256,14 @@ mod test {
             report_body,
             signature_len: 19,
             signature: Default::default(),
-        };
-        let alias_bytes: &[u8] = unsafe {
-            slice::from_raw_parts(
-                &quote as *const sgx_quote_t as *const u8,
-                mem::size_of::<sgx_quote_t>(),
-            )
-        };
-        let mut bytes: [u8; mem::size_of::<sgx_quote_t>()] = [0; mem::size_of::<sgx_quote_t>()];
-        bytes.copy_from_slice(alias_bytes);
-        bytes
+        }
     }
 
-    fn base_quote_2() -> [u8; mem::size_of::<sgx_quote_t>()] {
+    fn base_quote_2() -> sgx_quote_t {
         let mut report_body = sgx_report_body_t::default();
         report_body.misc_select = 28;
 
-        let quote = sgx_quote_t {
+        sgx_quote_t {
             version: 21,
             sign_type: 1,
             epid_group_id: [23u8; 4],
@@ -267,16 +274,7 @@ mod test {
             report_body,
             signature_len: 29,
             signature: Default::default(),
-        };
-        let alias_bytes: &[u8] = unsafe {
-            slice::from_raw_parts(
-                &quote as *const sgx_quote_t as *const u8,
-                mem::size_of::<sgx_quote_t>(),
-            )
-        };
-        let mut bytes: [u8; mem::size_of::<sgx_quote_t>()] = [0; mem::size_of::<sgx_quote_t>()];
-        bytes.copy_from_slice(alias_bytes);
-        bytes
+        }
     }
 
     #[test]
@@ -303,7 +301,7 @@ mod test {
 
     #[test]
     fn quote_from_bytes_1x() {
-        let quote_bytes = base_quote_1();
+        let quote_bytes = quote_to_bytes(base_quote_1());
         let quote = Quote::from(quote_bytes.as_slice());
         assert_eq!(quote.version(), 11.into());
         assert_eq!(
@@ -329,7 +327,7 @@ mod test {
 
     #[test]
     fn quote_from_bytes_2x() {
-        let quote_bytes = base_quote_2();
+        let quote_bytes = quote_to_bytes(base_quote_2());
         let quote = Quote::from(quote_bytes.as_slice());
         assert_eq!(quote.version(), 21.into());
         assert_eq!(

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -242,7 +242,10 @@ mod test {
             misc_select: 2,
             reserved1: [3u8; SGX_REPORT_BODY_RESERVED1_BYTES],
             isv_ext_prod_id: [4u8; SGX_ISVEXT_PROD_ID_SIZE],
-            attributes: Attributes::default().set_flags(5).set_transform(6).into(),
+            attributes: Attributes::default()
+                .set_flags(5)
+                .set_extended_features_mask(6)
+                .into(),
             mr_enclave: MrEnclave::from([7u8; MrEnclave::SIZE]).into(),
             reserved2: [8u8; SGX_REPORT_BODY_RESERVED2_BYTES],
             mr_signer: MrSigner::from([9u8; MrSigner::SIZE]).into(),
@@ -265,7 +268,10 @@ mod test {
             misc_select: 22,
             reserved1: [32u8; SGX_REPORT_BODY_RESERVED1_BYTES],
             isv_ext_prod_id: [42u8; SGX_ISVEXT_PROD_ID_SIZE],
-            attributes: Attributes::default().set_flags(52).set_transform(62).into(),
+            attributes: Attributes::default()
+                .set_flags(52)
+                .set_extended_features_mask(62)
+                .into(),
             mr_enclave: MrEnclave::from([72u8; MrEnclave::SIZE]).into(),
             reserved2: [82u8; SGX_REPORT_BODY_RESERVED2_BYTES],
             mr_signer: MrSigner::from([92u8; MrSigner::SIZE]).into(),
@@ -282,7 +288,12 @@ mod test {
         }
     }
 
+    #[allow(unsafe_code)]
     fn report_body_to_bytes(body: sgx_report_body_t) -> [u8; mem::size_of::<sgx_report_body_t>()] {
+        // SAFETY: This is a test only function. The size of `body` is used for
+        // reinterpretation of `body` into a byte slice. The slice is copied
+        // from prior to the leaving of this function ensuring the raw pointer
+        // is not persisted.
         let alias_bytes: &[u8] = unsafe {
             slice::from_raw_parts(
                 &body as *const sgx_report_body_t as *const u8,
@@ -320,14 +331,16 @@ mod test {
         let bytes = report_body_to_bytes(report_body_1());
         let body = ReportBody::from(bytes);
         assert_eq!(body.cpu_svn(), CpuSvn::from([1u8; CpuSvn::SIZE]));
-        assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::new(2));
+        assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::from(2));
         assert_eq!(
             body.isv_extended_product_id(),
             ExtendedProductId([4u8; SGX_ISVEXT_PROD_ID_SIZE])
         );
         assert_eq!(
             body.attributes(),
-            Attributes::default().set_flags(5).set_transform(6)
+            Attributes::default()
+                .set_flags(5)
+                .set_extended_features_mask(6)
         );
         assert_eq!(
             body.mr_enclave(),
@@ -339,8 +352,8 @@ mod test {
         );
         assert_eq!(body.config_id(), ConfigId::from([11u8; SGX_CONFIGID_SIZE]));
         assert_eq!(body.isv_product_id(), IsvProductId(12));
-        assert_eq!(body.isv_svn(), IsvSvn::new(13));
-        assert_eq!(body.config_svn(), ConfigSvn::new(14));
+        assert_eq!(body.isv_svn(), IsvSvn::from(13));
+        assert_eq!(body.config_svn(), ConfigSvn::from(14));
         assert_eq!(
             body.isv_family_id(),
             FamilyId([16u8; SGX_ISV_FAMILY_ID_SIZE])
@@ -358,14 +371,16 @@ mod test {
         let bytes = report_body_to_bytes(report_body_2());
         let body = ReportBody::from(bytes);
         assert_eq!(body.cpu_svn(), CpuSvn::from([12u8; CpuSvn::SIZE]));
-        assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::new(22));
+        assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::from(22));
         assert_eq!(
             body.isv_extended_product_id(),
             ExtendedProductId([42u8; SGX_ISVEXT_PROD_ID_SIZE])
         );
         assert_eq!(
             body.attributes(),
-            Attributes::default().set_flags(52).set_transform(62)
+            Attributes::default()
+                .set_flags(52)
+                .set_extended_features_mask(62)
         );
         assert_eq!(
             body.mr_enclave(),
@@ -377,8 +392,8 @@ mod test {
         );
         assert_eq!(body.config_id(), ConfigId::from([112u8; SGX_CONFIGID_SIZE]));
         assert_eq!(body.isv_product_id(), IsvProductId(122));
-        assert_eq!(body.isv_svn(), IsvSvn::new(132));
-        assert_eq!(body.config_svn(), ConfigSvn::new(142));
+        assert_eq!(body.isv_svn(), IsvSvn::from(132));
+        assert_eq!(body.config_svn(), ConfigSvn::from(142));
         assert_eq!(
             body.isv_family_id(),
             FamilyId([162u8; SGX_ISV_FAMILY_ID_SIZE])

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -4,6 +4,7 @@
 use crate::{impl_newtype_for_bytestruct, new_type_accessors_impls};
 use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_CPUSVN_SIZE};
 
+/// Config security version number (SVN)
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 pub struct ConfigSvn(sgx_config_svn_t);
@@ -12,12 +13,7 @@ new_type_accessors_impls! {
     ConfigSvn, sgx_config_svn_t;
 }
 
-impl ConfigSvn {
-    pub fn new(svn: u16) -> Self {
-        ConfigSvn(svn)
-    }
-}
-
+/// Independent software vendor (ISV) security version number (SVN)
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
 pub struct IsvSvn(sgx_isv_svn_t);
@@ -26,12 +22,7 @@ new_type_accessors_impls! {
     IsvSvn, sgx_isv_svn_t;
 }
 
-impl IsvSvn {
-    pub fn new(svn: u16) -> Self {
-        IsvSvn(svn)
-    }
-}
-
+/// CPU security version number (SVN)
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct CpuSvn(sgx_cpu_svn_t);

--- a/core/types/src/target_info.rs
+++ b/core/types/src/target_info.rs
@@ -69,7 +69,10 @@ mod test {
     fn from_target_info_t() {
         let info = sgx_target_info_t {
             mr_enclave: MrEnclave::from([1u8; MrEnclave::SIZE]).into(),
-            attributes: Attributes::default().set_flags(2).set_transform(3).into(),
+            attributes: Attributes::default()
+                .set_flags(2)
+                .set_extended_features_mask(3)
+                .into(),
             reserved1: [4u8; SGX_TARGET_INFO_RESERVED1_BYTES],
             config_svn: 5,
             misc_select: 6,
@@ -86,10 +89,12 @@ mod test {
         );
         assert_eq!(
             info.attributes(),
-            Attributes::default().set_flags(2).set_transform(3)
+            Attributes::default()
+                .set_flags(2)
+                .set_extended_features_mask(3)
         );
-        assert_eq!(info.config_svn(), ConfigSvn::new(5));
-        assert_eq!(info.miscellaneous_select(), MiscellaneousSelect::new(6));
+        assert_eq!(info.config_svn(), ConfigSvn::from(5));
+        assert_eq!(info.miscellaneous_select(), MiscellaneousSelect::from(6));
         assert_eq!(info.config_id(), ConfigId::from([8; SGX_CONFIGID_SIZE]));
     }
 }

--- a/tservice/types/src/diffie_hellman.rs
+++ b/tservice/types/src/diffie_hellman.rs
@@ -3,6 +3,7 @@
 use mc_sgx_core_types::impl_newtype_for_bytestruct;
 use mc_sgx_tservice_sys_types::{sgx_dh_session_t, SGX_DH_SESSION_DATA_SIZE};
 
+/// A session used in Diffie Hellman (DH) secure session establishment
 #[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Session(sgx_dh_session_t);

--- a/tservice/types/src/lib.rs
+++ b/tservice/types/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![doc = include_str!("../README.md")]
 #![no_std]
+#![deny(missing_docs, missing_debug_implementations, unsafe_code)]
 
 mod diffie_hellman;
 


### PR DESCRIPTION
`mc-sgx-core-types` and `mc-sgx-tservice-types` crates will now error on
`missing_docs`, `missing_debug_implementations`, and `unsafe_code`