### PR TITLE
Use sparse registry for cargo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"
+  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 jobs:
   rustfmt:


### PR DESCRIPTION
Turned on the sparse registry for Cargo,
https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
This speeds up cargo operations

The effect can be seen by looking at the cargo steps from:
- [467](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030364866) with sparse registry
- [468](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030369463) without sparse registry
- [469](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030369468) without sparse registry
- [470](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030379919) with sparse registry
- [471](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030383013) with sparse registry
- [472](https://github.com/mobilecoinfoundation/sgx/actions/runs/3030397945) with sparse registry

One can also test this out locally via
```shell
git checkout Cargo.lock
rm -rf ~/.cargo/registry 
time CARGO_UNSTABLE_SPARSE_REGISTRY=true cargo update   

git checkout Cargo.lock
rm -rf ~/.cargo/registry
time cargo update
```
Note the `git checkout Cargo.lock` is to undo the `update` process thus providing similar output between commands

Because of the global effect chose to use the environment variable in the GHA files instead of using `.cargo/config.toml` in the repo