### PR TITLE
Add rust enclave report create and verify wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
 name = "mc-sgx-tservice"
 version = "0.2.0-pre0"
 dependencies = [
+ "mc-sgx-core-sys-types",
  "mc-sgx-core-types",
  "mc-sgx-tservice-sys",
  "mc-sgx-tservice-sys-types",

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -26,7 +26,7 @@ pub use crate::{
     error::{Error, FfiError, Result},
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},
     measurement::{Measurement, MrEnclave, MrSigner},
-    report::ReportBody,
+    report::{Report, ReportBody, ReportData},
     svn::{ConfigSvn, CpuSvn, IsvSvn},
     target_info::TargetInfo,
 };

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -197,6 +197,7 @@ impl From<[u8; mem::size_of::<sgx_report_body_t>()]> for ReportBody {
     }
 }
 
+/// An enclave Report
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Report(sgx_report_t);

--- a/tservice/Cargo.toml
+++ b/tservice/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
 
 [dependencies]
+mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.2.0-pre0" }
 mc-sgx-core-types = { path = "../core/types", version = "=0.2.0-pre0" }
 mc-sgx-tservice-sys = { path = "sys", version = "=0.2.0-pre0" }
 mc-sgx-tservice-sys-types = { path = "sys/types", version = "=0.2.0-pre0" }

--- a/tservice/src/lib.rs
+++ b/tservice/src/lib.rs
@@ -6,6 +6,10 @@
 
 extern crate alloc;
 
+mod report;
 mod seal;
 
-pub use crate::seal::SealedBuilder;
+pub use crate::{
+    report::Report,
+    seal::{SealedBuilder, Unseal},
+};

--- a/tservice/src/report.rs
+++ b/tservice/src/report.rs
@@ -7,17 +7,24 @@ use mc_sgx_core_types::{ReportData, Result, TargetInfo};
 use mc_sgx_util::ResultInto;
 
 /// Report operations that can be performed inside of an enclave
-pub trait Report {
+pub trait Report: Sized {
     /// Creates a report for the current enclave.
     ///
     /// # Arguments
     /// * `target_info` - The information for the target enclave which will
-    ///   cryptographically verify the report.  See [`Report::verify_report()`].
+    ///   cryptographically verify the report.  See [`Report::verify()`].
     /// * `report_data` - Report data used to communicate between enclaves
-    fn create_report(
-        target_info: &TargetInfo,
-        report_data: Option<&ReportData>,
-    ) -> Result<mc_sgx_core_types::Report> {
+    fn new(target_info: &TargetInfo, report_data: Option<&ReportData>) -> Result<Self>;
+
+    /// Verify an enclave report
+    ///
+    /// Ok means that the report was generated using a [`TargetInfo`] that
+    /// matches the one for the enclave making this call.
+    fn verify(&self) -> Result<()>;
+}
+
+impl Report for mc_sgx_core_types::Report {
+    fn new(target_info: &TargetInfo, report_data: Option<&ReportData>) -> Result<Self> {
         let mut report = sgx_report_t::default();
         unsafe {
             mc_sgx_tservice_sys::sgx_create_report(
@@ -30,15 +37,8 @@ pub trait Report {
         Ok(report.into())
     }
 
-    /// Verify an enclave report
-    ///
-    /// Ok means that the input report was generated using a [`TargetInfo`]
-    /// that matches the one for the enclave making this call.
-    ///
-    /// # Arguments
-    /// * `report` - The report to verify
-    fn verify_report(report: &mc_sgx_core_types::Report) -> Result<()> {
-        unsafe { mc_sgx_tservice_sys::sgx_verify_report(report.as_ref()) }.into_result()?;
+    fn verify(&self) -> Result<()> {
+        unsafe { mc_sgx_tservice_sys::sgx_verify_report(self.as_ref()) }.into_result()?;
         Ok(())
     }
 }

--- a/tservice/src/report.rs
+++ b/tservice/src/report.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+//! Functions used for creating and verifying reports inside of an enclave
+
+use core::ptr;
+use mc_sgx_core_sys_types::sgx_report_t;
+use mc_sgx_core_types::{ReportData, Result, TargetInfo};
+use mc_sgx_util::ResultInto;
+
+/// Report operations that can be performed inside of an enclave
+pub trait Report {
+    /// Creates a report for the current enclave.
+    ///
+    /// # Arguments
+    /// * `target_info` - The information for the target enclave which will
+    ///   cryptographically verify the report.  See [`Report::verify_report()`].
+    /// * `report_data` - Report data used to communicate between enclaves
+    fn create_report(
+        target_info: &TargetInfo,
+        report_data: Option<&ReportData>,
+    ) -> Result<mc_sgx_core_types::Report> {
+        let mut report = sgx_report_t::default();
+        unsafe {
+            mc_sgx_tservice_sys::sgx_create_report(
+                target_info.as_ref(),
+                report_data.map_or_else(ptr::null, |data| data.as_ref()),
+                &mut report,
+            )
+        }
+        .into_result()?;
+        Ok(report.into())
+    }
+
+    /// Verify an enclave report
+    ///
+    /// Ok means that the input report was generated using a [`TargetInfo`]
+    /// that matches the one for the enclave making this call.
+    ///
+    /// # Arguments
+    /// * `report` - The report to verify
+    fn verify_report(report: &mc_sgx_core_types::Report) -> Result<()> {
+        unsafe { mc_sgx_tservice_sys::sgx_verify_report(report.as_ref()) }.into_result()?;
+        Ok(())
+    }
+}

--- a/tservice/src/seal.rs
+++ b/tservice/src/seal.rs
@@ -90,6 +90,9 @@ impl<T: AsRef<[u8]> + core::default::Default> SealedBuilder<T> {
     }
 }
 
+/// Unseal data.
+///
+/// Functionality to convert sealed (encrypted) data to unsealed, unencrypted
 pub trait Unseal: AsRef<[u8]> {
     /// The length (in bytes) needed to hold the decrypted text
     fn decrypted_text_len(&self) -> Result<usize> {


### PR DESCRIPTION
A new trait has been added `mc-sgx-tservice::Report` which provides
functionality to create an `mc-sgx-core-types::Report` and to verify a
`mc-sgx-core-types::Report`.  This functionality operates inside of an
enclave.