### PR TITLE
Limit size labels to pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,8 @@ jobs:
 
   size-label:
     runs-on: ubuntu-20.04
+    # Trying to size a non pull request will error out failing the build
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
Previously the size label was applied to pull requests and mainline
commits. Trying to size mainline commits would error out and fail the
build.