### PR TITLE
Do the builder include_path stuff automatically.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ name = "mc-sgx-core-build"
 version = "0.2.0-pre0"
 dependencies = [
  "bindgen",
+ "cargo-emit",
 ]
 
 [[package]]

--- a/capable/sys/build.rs
+++ b/capable/sys/build.rs
@@ -3,9 +3,6 @@
 //! Builds the FFI type bindings for the types used by libsgx_capable.{so,a}.
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rerun_if_changed!(link_path);
     cargo_emit::rustc_link_search!(link_path);
@@ -13,7 +10,6 @@ fn main() {
 
     mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .allowlist_function("sgx_is_capable")
         .allowlist_function("sgx_cap_enable_device")
         .allowlist_function("sgx_cap_get_status")

--- a/capable/sys/types/build.rs
+++ b/capable/sys/types/build.rs
@@ -5,14 +5,10 @@
 use mc_sgx_core_build::SgxParseCallbacks;
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let callback = SgxParseCallbacks::default().enum_types(["sgx_device_status_t"]);
 
     mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .allowlist_type("_sgx_device_status_t")
         .parse_callbacks(Box::new(callback))
         .generate()

--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.62.1"
 
 [dependencies]
 bindgen = "0.60.1"
+cargo-emit = "0.2.1"
 
 [package.metadata.release]
 # Workaround for settings in root Cargo.toml applying to *all* crates during

--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -58,7 +58,9 @@ pub fn normalize_item_name(name: &str) -> Option<String> {
 /// Returns a builder configured with the defaults for using bindgen with the
 /// SGX libraries.
 pub fn sgx_builder() -> Builder {
-    Builder::default()
+    let include_path = sgx_include_string();
+
+    let builder = Builder::default()
         .derive_copy(false)
         .derive_debug(false)
         .default_enum_style(EnumVariation::NewType { is_bitfield: false })
@@ -67,6 +69,11 @@ pub fn sgx_builder() -> Builder {
         .ctypes_prefix("core::ffi")
         .allowlist_recursively(false)
         .parse_callbacks(Box::new(SgxParseCallbacks::default()))
+        .clang_arg(&format!("-I{}", include_path));
+
+    cargo_emit::rerun_if_changed!(include_path);
+
+    builder
 }
 
 /// SGXParseCallbacks to be used with [bindgen::Builder::parse_callbacks]

--- a/core/sys/types/build.rs
+++ b/core/sys/types/build.rs
@@ -112,7 +112,6 @@ fn main() {
         ]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback))
         .newtype_enum("_status_t");
 

--- a/core/sys/types/build.rs
+++ b/core/sys/types/build.rs
@@ -83,7 +83,6 @@ const CORE_CONSTS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
     let callback = SgxParseCallbacks::default()
         .enum_types(["sgx_status_t", "sgx_quote_sign_type_t"])
         .derive_copy([

--- a/dcap/ql/sys/build.rs
+++ b/dcap/ql/sys/build.rs
@@ -18,7 +18,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in DCAP_QL_FUNCTIONS {

--- a/dcap/ql/sys/build.rs
+++ b/dcap/ql/sys/build.rs
@@ -11,9 +11,6 @@ const DCAP_QL_FUNCTIONS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     cargo_emit::rustc_link_lib!("dylib=sgx_dcap_ql");
 
     let mut builder = mc_sgx_core_build::sgx_builder()

--- a/dcap/ql/sys/types/build.rs
+++ b/dcap/ql/sys/types/build.rs
@@ -10,13 +10,9 @@ const DCAP_QL_TYPES: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let callback = SgxParseCallbacks::default().enum_types(["sgx_ql_path_type_t"]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback))
         .blocklist_function("*");
 

--- a/dcap/quoteverify/sys/build.rs
+++ b/dcap/quoteverify/sys/build.rs
@@ -19,7 +19,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in DCAP_QL_FUNCTIONS {

--- a/dcap/quoteverify/sys/build.rs
+++ b/dcap/quoteverify/sys/build.rs
@@ -12,9 +12,6 @@ const DCAP_QL_FUNCTIONS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     cargo_emit::rustc_link_lib!("dylib=sgx_dcap_quoteverify");
 
     let mut builder = mc_sgx_core_build::sgx_builder()

--- a/dcap/quoteverify/sys/types/build.rs
+++ b/dcap/quoteverify/sys/types/build.rs
@@ -7,13 +7,9 @@ use mc_sgx_core_build::SgxParseCallbacks;
 const DCAP_QUOTEVERIFY_TYPES: &[&str] = &["sgx_qv_path_type_t"];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let callback = SgxParseCallbacks::default().enum_types(["sgx_qv_path_type_t"]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback))
         .blocklist_function("*");
 

--- a/dcap/tvl/sys/build.rs
+++ b/dcap/tvl/sys/build.rs
@@ -4,9 +4,6 @@
 const DCAP_TVL_FUNCTIONS: &[&str] = &["sgx_tvl_verify_qve_report_and_identity"];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rustc_link_search!(link_path);
     cargo_emit::rerun_if_changed!(link_path);
@@ -14,7 +11,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in DCAP_TVL_FUNCTIONS {

--- a/tcrypto/sys/build.rs
+++ b/tcrypto/sys/build.rs
@@ -60,9 +60,6 @@ const CRYPTO_FUNCTIONS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rerun_if_changed!(link_path);
     cargo_emit::rustc_link_search!(link_path);
@@ -70,7 +67,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in CRYPTO_FUNCTIONS {

--- a/tcrypto/sys/types/build.rs
+++ b/tcrypto/sys/types/build.rs
@@ -42,12 +42,9 @@ fn main() {
             "sgx_generic_ecresult_t",
         ])
         .derive_copy(["sgx_ec256_public_t", "rsa_params_t"]);
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback))
         .blocklist_function("*");
 

--- a/trts/sys/build.rs
+++ b/trts/sys/build.rs
@@ -18,9 +18,6 @@ const TRTS_FUNCTIONS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rerun_if_changed!(link_path);
     cargo_emit::rustc_link_search!(link_path);
@@ -30,7 +27,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in TRTS_FUNCTIONS {

--- a/tservice/sys/build.rs
+++ b/tservice/sys/build.rs
@@ -32,9 +32,6 @@ const SERVICE_FUNCTIONS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rerun_if_changed!(link_path);
     cargo_emit::rustc_link_search!(link_path);
@@ -44,7 +41,6 @@ fn main() {
 
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*");
 
     for f in SERVICE_FUNCTIONS {

--- a/tservice/sys/types/build.rs
+++ b/tservice/sys/types/build.rs
@@ -48,7 +48,6 @@ fn main() {
         .derive_default(["sgx_sealed_data_t", "sgx_aes_gcm_data_t"]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback))
         .blocklist_function("*");
 

--- a/tservice/sys/types/build.rs
+++ b/tservice/sys/types/build.rs
@@ -28,9 +28,6 @@ const SERVICE_TYPES: &[&str] = &[
 const SERVICE_CONSTS: &[&str] = &["SGX_DH_SESSION_DATA_SIZE"];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let callback = SgxParseCallbacks::default()
         .enum_types(["sgx_dh_session_role_t"])
         .derive_copy([

--- a/tstdc/sys/build.rs
+++ b/tstdc/sys/build.rs
@@ -4,9 +4,6 @@
 //! Intel SGX SDK
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rerun_if_changed!(link_path);
     cargo_emit::rustc_link_search!(link_path);
@@ -15,7 +12,6 @@ fn main() {
     let out_path = mc_sgx_core_build::build_output_dir();
     mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .blocklist_type("*")
         .allowlist_function("sgx_thread.*")
         .allowlist_function("sgx_alloc.*")

--- a/tstdc/sys/types/build.rs
+++ b/tstdc/sys/types/build.rs
@@ -19,16 +19,12 @@ impl ParseCallbacks for TstdcParseCallbacks {
 }
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let out_path = mc_sgx_core_build::build_output_dir();
 
     mc_sgx_core_build::sgx_builder()
         // override the default ParseCallbacks impl provided by mc_sgx_core_build
         .parse_callbacks(Box::new(TstdcParseCallbacks))
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .allowlist_recursively(false)
         .allowlist_type("sgx_thread_t")
         .allowlist_type("_sgx_thread_queue_t")

--- a/urts/sys/build.rs
+++ b/urts/sys/build.rs
@@ -20,9 +20,6 @@ const URTS_CONSTANTS: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let link_path = mc_sgx_core_build::sgx_library_string();
     cargo_emit::rustc_link_search!(link_path);
 
@@ -31,9 +28,7 @@ fn main() {
     cargo_emit::rustc_link_lib!(&format!("sgx_urts{}", sgx_suffix));
     cargo_emit::rustc_link_lib!(&format!("sgx_uae_service{}", sgx_suffix));
 
-    let mut builder = mc_sgx_core_build::sgx_builder()
-        .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path));
+    let mut builder = mc_sgx_core_build::sgx_builder().header("wrapper.h");
 
     for f in URTS_FUNCTIONS {
         builder = builder.allowlist_function(f);

--- a/urts/sys/types/build.rs
+++ b/urts/sys/types/build.rs
@@ -17,7 +17,6 @@ fn main() {
     let callback = SgxParseCallbacks::default().derive_copy(["sgx_kss_config_t"]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")
-        .clang_arg(&format!("-I{}", include_path))
         .parse_callbacks(Box::new(callback));
 
     for t in URTS_TYPES {

--- a/urts/sys/types/build.rs
+++ b/urts/sys/types/build.rs
@@ -11,9 +11,6 @@ const URTS_TYPES: &[&str] = &[
 ];
 
 fn main() {
-    let include_path = mc_sgx_core_build::sgx_include_string();
-    cargo_emit::rerun_if_changed!(include_path);
-
     let callback = SgxParseCallbacks::default().derive_copy(["sgx_kss_config_t"]);
     let mut builder = mc_sgx_core_build::sgx_builder()
         .header("wrapper.h")


### PR DESCRIPTION
This PR adds the include_path handling to the bindgen builder created by sgx_builder() so it's automatically handled.
