### PR TITLE
Add specific errors for sealing failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "mc-sgx-tservice-sys-types",
  "mc-sgx-tservice-types",
  "mc-sgx-util",
+ "yare",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
 name = "mc-sgx-tservice"
 version = "0.2.1"
 dependencies = [
+ "displaydoc",
  "mc-sgx-core-sys-types",
  "mc-sgx-core-types",
  "mc-sgx-tservice-sys",

--- a/tservice/Cargo.toml
+++ b/tservice/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
 
 [dependencies]
+displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.2.1" }
 mc-sgx-core-types = { path = "../core/types", version = "=0.2.1" }
 mc-sgx-tservice-sys = { path = "sys", version = "=0.2.1" }

--- a/tservice/Cargo.toml
+++ b/tservice/Cargo.toml
@@ -23,3 +23,4 @@ mc-sgx-util = { path = "../util", version = "=0.2.1" }
 
 [dev-dependencies]
 mc-sgx-tservice-types = { path = "types", version = "=0.2.1", features = [ "test-utils" ] }
+yare = "1.0.2"

--- a/tservice/src/seal.rs
+++ b/tservice/src/seal.rs
@@ -28,11 +28,11 @@ pub enum Error {
     Sgx(mc_sgx_core_types::Error),
     /// FFI error {0}
     Ffi(mc_sgx_core_types::FfiError),
-    /** The data and AAD to seal is too large.
-     *  Data size: {data_size}, AAD size: {aad_size} */
+    /** The combined plaintext ({data_size}) and authenticated data
+     *  ({aad_size}) sizes are larger than 4GiB */
     DataAadOverflow { data_size: usize, aad_size: usize },
-    /** The provided buffer to store unsealed data in is too small.
-     *  Buffer size: {buffer_size}, needed size {needed_size} */
+    /** The destination buffer must be at least {needed_size} bytes,
+     *  {buffer_size} was given */
     UnsealedBufferTooSmall {
         buffer_size: usize,
         needed_size: usize,

--- a/tservice/src/seal.rs
+++ b/tservice/src/seal.rs
@@ -2,7 +2,7 @@
 //! Functions used for sealing and unsealing of secrets
 
 use alloc::{format, string::String, vec, vec::Vec};
-use core::{ptr, result::Result as CoreResult};
+use core::{mem, ptr, result::Result as CoreResult};
 use mc_sgx_core_types::{Attributes, KeyPolicy, MiscellaneousSelect};
 use mc_sgx_tservice_sys_types::sgx_sealed_data_t;
 pub use mc_sgx_tservice_types::Sealed;
@@ -28,13 +28,15 @@ pub enum Error {
     Sgx(mc_sgx_core_types::Error),
     /// FFI error {0}
     Ffi(mc_sgx_core_types::FfiError),
-    /// Failed calculating the sealed data size, `sgx_calc_sealed_data_size()`
-    CalculateSealedDataSize,
-    /** Failed getting the decrypted data size `sgx_get_encrypt_txt_len()`
-     *  (Yes it is `decrypted` data size with a function named `encrypt`) */
-    GetDecryptedDataSize,
-    /// Invalid parameter: {0}
-    InvalidParameter(String),
+    /** The data and AAD to seal is too large.
+     *  Data size: {data_size}, AAD size: {aad_size} */
+    DataAadOverflow { data_size: usize, aad_size: usize },
+    /** The provided buffer to store unsealed data in is too small.
+     *  Buffer size: {buffer_size}, needed size {needed_size} */
+    UnsealedBufferTooSmall {
+        buffer_size: usize,
+        needed_size: usize,
+    },
     /// Unexpected behavior from the SGX interface: {0}
     Unexpected(String),
 }
@@ -136,26 +138,50 @@ impl<T: AsRef<[u8]> + Default> SealedBuilder<T> {
 
     /// Returns the size needed to seal the data
     fn sealed_size(&self) -> Result<usize> {
-        let aad_length = match &self.aad {
+        let aad_size = match &self.aad {
             Some(aad) => aad.as_ref().len() as u32,
             None => 0,
         };
 
-        let result = unsafe {
-            mc_sgx_tservice_sys::sgx_calc_sealed_data_size(
-                aad_length,
-                self.data.as_ref().len() as u32,
-            )
-        };
+        let data_size = self.data.as_ref().len() as u32;
+
+        Self::check_sealed_size_overflow(data_size as u64, aad_size as u64)?;
+
+        let result = unsafe { mc_sgx_tservice_sys::sgx_calc_sealed_data_size(aad_size, data_size) };
 
         match result {
             // Per the documentation, UINT32_MAX indicates an error
-            u32::MAX => Err(Error::CalculateSealedDataSize),
+            // This shouldn't happen with the `check_sealed_size_overflow` call
+            // above, but the logic is kept here in case the SGX SDK adds other
+            // validation checks that aren't covered in
+            // `check_sealed_size_overflow`.
+            u32::MAX => Err(Error::DataAadOverflow {
+                data_size: data_size as usize,
+                aad_size: aad_size as usize,
+            }),
             size => Ok(size as usize),
         }
     }
+
     fn validate_inputs(&self) -> Result<()> {
         Ok(())
+    }
+
+    fn check_sealed_size_overflow(data_size: u64, aad_size: u64) -> Result<()> {
+        let overall_size = data_size + aad_size + mem::size_of::<sgx_sealed_data_t>() as u64;
+
+        // NB: There appears to be an off by one in the
+        // `sgx_calc_sealed_data_size()`.  It conditions for `a > MAX - b`.
+        // Without overflows this can be interpreted as `a + b > MAX`.  This
+        // means when `a + b == MAX` it follows the happy path returning MAX.
+        if overall_size >= u32::MAX as u64 {
+            Err(Error::DataAadOverflow {
+                data_size: data_size as usize,
+                aad_size: aad_size as usize,
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -171,8 +197,12 @@ pub trait Unseal: AsRef<[u8]> {
             )
         };
         match result {
-            // Per the documentation, UINT32_MAX indicates an error
-            u32::MAX => Err(Error::GetDecryptedDataSize),
+            // Per the documentation, UINT32_MAX indicates an error, however
+            // this should only happen if we passed in a NULL pointer, which we
+            // prevent with the trait bounds
+            u32::MAX => Err(Error::Unexpected(String::from(
+                "Failed to get the decrypted text length.",
+            ))),
             size => Ok(size as usize),
         }
     }
@@ -189,11 +219,10 @@ pub trait Unseal: AsRef<[u8]> {
     fn unseal<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a mut [u8]> {
         let data_length = self.decrypted_text_len()?;
         if buffer.len() < data_length {
-            return Err(Error::InvalidParameter(format!(
-                "'buffer', with length {}, to 'Unseal::unseal()' is too small for needed size of {}",
-                buffer.len(),
-                data_length
-            )));
+            return Err(Error::UnsealedBufferTooSmall {
+                buffer_size: buffer.len(),
+                needed_size: data_length,
+            });
         }
 
         let mut data_length_u32 = data_length as u32;
@@ -236,8 +265,8 @@ impl<T: AsRef<[u8]>> Unseal for Sealed<T> {}
 #[cfg(test)]
 mod test {
     use super::*;
-    use core::mem;
     use mc_sgx_tservice_types::test_utils;
+    use yare::parameterized;
 
     #[test]
     fn sealed_data_size() {
@@ -253,6 +282,37 @@ mod test {
         let builder = SealedBuilder::new(b"1234567".as_slice());
         let expected_size = mem::size_of::<sgx_sealed_data_t>() + builder.data.len();
         assert_eq!(builder.sealed_size(), Ok(expected_size));
+    }
+
+    #[parameterized(
+    zeros = {0, 0},
+    one_two = {1, 2},
+    maxed_data = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1, 0},
+    maxed_aad = {0, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1},
+    half_way = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2},
+    almost_maxed_data_one_aad = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 2, 1},
+    )]
+    fn no_sealed_size_overflow(data_size: usize, aad_size: usize) {
+        assert_eq!(
+            SealedBuilder::<&[u8]>::check_sealed_size_overflow(data_size as u64, aad_size as u64),
+            Ok(())
+        );
+    }
+
+    #[parameterized(
+    data_overflow = {u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>(), 0},
+    aad_overflow = {0, u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()},
+    half_way = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2 + 1, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2},
+    data_overflow_one_aad = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1, 1},
+    )]
+    fn sealed_size_overflow(data_size: usize, aad_size: usize) {
+        assert_eq!(
+            SealedBuilder::<&[u8]>::check_sealed_size_overflow(data_size as u64, aad_size as u64),
+            Err(Error::DataAadOverflow {
+                data_size,
+                aad_size
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add errors that provide more information on why a failure to seal data
occurs.