### PR TITLE
Add validation of `data` and `aad` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `mc-sgx-tservice::SealedBuilder` utilizes the dedicated error type
-  `mc-sgx-tservice::SealError`. Previously `mc-sgx-tservice::SealedBuilder`
-  utilized `mc-sgx-core-types::Error`.
-- `mc-sgx-tservice::SealedBuilder::new()` and
-  `mc-sgx-tservice::SealedBuilder::aad()` are now fallible. This allows more
-  detailed errors to be provided for bad inputs.  Previously errors were
-  deferred until `mc-sgx-tservice::SealedBuilder::build()`, propagating the
-  generic `mc-sgx-core-types::Error::InvalidParameter` error.
+- Add `mc_sgx_tservice::SealError`, make `SealedBuilder` use it instead of
+  `mc_sgx_core_types::Error`.
   
 ## [0.2.1] - 2022-10-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `mc-sgx-tservice::SealedBuilder` utilizes the dedicated error type
+  `mc-sgx-tservice::SealError`. Previously `mc-sgx-tservice::SealedBuilder`
+  utilized `mc-sgx-core-types::Error`.
+- `mc-sgx-tservice::SealedBuilder::new()` and
+  `mc-sgx-tservice::SealedBuilder::aad()` are now fallible. This allows more
+  detailed errors to be provided for bad inputs.  Previously errors were
+  deferred until `mc-sgx-tservice::SealedBuilder::build()`, propagating the
+  generic `mc-sgx-core-types::Error::InvalidParameter` error.
+  
 ## [0.2.1] - 2022-10-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "displaydoc",
  "mc-sgx-core-sys-types",
  "mc-sgx-core-types",
+ "mc-sgx-trts",
  "mc-sgx-tservice-sys",
  "mc-sgx-tservice-sys-types",
  "mc-sgx-tservice-types",

--- a/trts/src/lib.rs
+++ b/trts/src/lib.rs
@@ -4,37 +4,29 @@
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use core::{ffi::c_void, mem};
+use core::ffi::c_void;
 use mc_sgx_trts_sys::{sgx_is_outside_enclave, sgx_is_within_enclave};
 
 /// Behavior for determining where memory values are at.
 pub trait EnclaveMemory<T> {
     /// Is the item fully within the enclave's memory space?
-    ///
-    /// # Arguments
-    /// - `item` - The item to see if it's fully inside of the enclave's memory
-    ///   space
-    fn is_within_enclave(item: &T) -> bool;
+    fn is_within_enclave(&self) -> bool;
 
     /// Is the item fully outside of the enclave's memory space?
-    ///
-    /// # Arguments
-    /// - `item` - The item to see if it's fully outside of the enclave's memory
-    ///   space
-    fn is_outside_enclave(item: &T) -> bool;
+    fn is_outside_enclave(&self) -> bool;
 }
 
-impl<T: Sized> EnclaveMemory<T> for T {
-    fn is_within_enclave(item: &T) -> bool {
-        let start = item as *const _ as *const c_void;
-        let size = mem::size_of::<T>();
+impl<T: AsRef<[u8]>> EnclaveMemory<T> for T {
+    fn is_within_enclave(&self) -> bool {
+        let start = self.as_ref().as_ptr() as *const c_void;
+        let size = self.as_ref().len();
         let result = unsafe { sgx_is_within_enclave(start, size) };
         result == 1
     }
 
-    fn is_outside_enclave(item: &T) -> bool {
-        let start = item as *const _ as *const c_void;
-        let size = mem::size_of::<T>();
+    fn is_outside_enclave(&self) -> bool {
+        let start = self.as_ref().as_ptr() as *const c_void;
+        let size = self.as_ref().len();
         let result = unsafe { sgx_is_outside_enclave(start, size) };
         result == 1
     }

--- a/tservice/Cargo.toml
+++ b/tservice/Cargo.toml
@@ -8,14 +8,19 @@ license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/mobilecoinfoundation/sgx"
 description = "Rust wrappers for the `sgx_tservice` library."
-
 categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
+
+[lib]
+# test false due to needing trts, and thus an enclave to fully link
+test = false
+doctest = false
 
 [dependencies]
 displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-core-sys-types = { path = "../core/sys/types", version = "=0.2.1" }
 mc-sgx-core-types = { path = "../core/types", version = "=0.2.1" }
+mc-sgx-trts = { path = "../trts", version = "=0.2.1" }
 mc-sgx-tservice-sys = { path = "sys", version = "=0.2.1" }
 mc-sgx-tservice-sys-types = { path = "sys/types", version = "=0.2.1" }
 mc-sgx-tservice-types = { path = "types", version = "=0.2.1", features = [ "alloc" ] }

--- a/tservice/src/seal.rs
+++ b/tservice/src/seal.rs
@@ -1,9 +1,10 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 //! Functions used for sealing and unsealing of secrets
 
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{borrow::ToOwned, format, string::String, vec, vec::Vec};
 use core::{mem, ptr, result::Result as CoreResult};
 use mc_sgx_core_types::{Attributes, KeyPolicy, MiscellaneousSelect};
+use mc_sgx_trts::EnclaveMemory;
 use mc_sgx_tservice_sys_types::sgx_sealed_data_t;
 pub use mc_sgx_tservice_types::Sealed;
 use mc_sgx_util::ResultInto;
@@ -37,6 +38,8 @@ pub enum Error {
         buffer_size: usize,
         needed_size: usize,
     },
+    /// An invalid parameter
+    InvalidParameter(String),
     /// Unexpected behavior from the SGX interface: {0}
     Unexpected(String),
 }
@@ -72,17 +75,31 @@ impl<T: AsRef<[u8]> + Default> SealedBuilder<T> {
     ///
     /// # Arguments
     /// * `data` - The data to be encrypted/sealed
-    pub fn new(data: T) -> Self {
-        Self {
+    ///
+    /// # Errors
+    /// Returns `Error::InvalidParameter` ff `data` is empty or is not fully
+    /// within the enclaves memory space
+    pub fn new(data: T) -> Result<Self> {
+        if data.as_ref().is_empty() {
+            return Err(Error::InvalidParameter(
+                "'data' to 'SealedBuilder::new()' is empty.".to_owned(),
+            ));
+        }
+        if !data.is_within_enclave() {
+            return Err(Error::InvalidParameter(
+                "'data' to 'SealedBuilder::new()' is not within the enclave.".to_owned(),
+            ));
+        }
+
+        Ok(Self {
             data,
             policy: DEFAULT_KEY_POLICY_FOR_SEAL,
             aad: None,
-        }
+        })
     }
 
     /// Build the [`Sealed`] object
     pub fn build(&self) -> Result<Sealed<Vec<u8>>> {
-        self.validate_inputs()?;
         let sealed_size = self.sealed_size()?;
         let mut sealed_data = vec![0; sealed_size];
 
@@ -122,9 +139,27 @@ impl<T: AsRef<[u8]> + Default> SealedBuilder<T> {
     ///
     /// # Arguments
     /// * `aad` - The AAD to add to the sealed data
-    pub fn aad(&mut self, aad: T) -> &mut Self {
-        self.aad = Some(aad);
-        self
+    ///
+    /// # Errors
+    /// Returns `Error::InvalidParameter` if `aad` crosses an enclave memory
+    /// boundary. i.e. the `aad` is not fully in the enclave's memory or fully
+    /// outside of it.  The instance will be unmodified in these situations.
+    pub fn aad(&mut self, aad: T) -> Result<&mut Self> {
+        if aad.as_ref().is_empty() {
+            // In the sgx interface an empty `aad` and _no_ `aad` are one in the
+            // same, so we use `None` for consistent behavior here.
+            self.aad = None;
+            return Ok(self);
+        }
+
+        if aad.is_within_enclave() || aad.is_outside_enclave() {
+            self.aad = Some(aad);
+            Ok(self)
+        } else {
+            Err(Error::InvalidParameter(
+                "'aad' to 'SealedBuilder::aad()' crosses an enclave memory boundary".to_owned(),
+            ))
+        }
     }
 
     /// Set the key policy to use for the sealed data
@@ -161,10 +196,6 @@ impl<T: AsRef<[u8]> + Default> SealedBuilder<T> {
             }),
             size => Ok(size as usize),
         }
-    }
-
-    fn validate_inputs(&self) -> Result<()> {
-        Ok(())
     }
 
     fn check_sealed_size_overflow(data_size: u64, aad_size: u64) -> Result<()> {
@@ -261,77 +292,3 @@ pub trait Unseal: AsRef<[u8]> {
 }
 
 impl<T: AsRef<[u8]>> Unseal for Sealed<T> {}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use mc_sgx_tservice_types::test_utils;
-    use yare::parameterized;
-
-    #[test]
-    fn sealed_data_size() {
-        let mut builder = SealedBuilder::new(b"12345678".as_slice());
-        builder.aad(b"123".as_slice());
-        let expected_size =
-            mem::size_of::<sgx_sealed_data_t>() + builder.data.len() + builder.aad.unwrap().len();
-        assert_eq!(builder.sealed_size(), Ok(expected_size));
-    }
-
-    #[test]
-    fn sealed_data_size_no_aad() {
-        let builder = SealedBuilder::new(b"1234567".as_slice());
-        let expected_size = mem::size_of::<sgx_sealed_data_t>() + builder.data.len();
-        assert_eq!(builder.sealed_size(), Ok(expected_size));
-    }
-
-    #[parameterized(
-    zeros = {0, 0},
-    one_two = {1, 2},
-    maxed_data = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1, 0},
-    maxed_aad = {0, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1},
-    half_way = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2},
-    almost_maxed_data_one_aad = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 2, 1},
-    )]
-    fn no_sealed_size_overflow(data_size: usize, aad_size: usize) {
-        assert_eq!(
-            SealedBuilder::<&[u8]>::check_sealed_size_overflow(data_size as u64, aad_size as u64),
-            Ok(())
-        );
-    }
-
-    #[parameterized(
-    data_overflow = {u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>(), 0},
-    aad_overflow = {0, u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()},
-    half_way = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2 + 1, (u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) / 2},
-    data_overflow_one_aad = {(u32::MAX as usize - mem::size_of::<sgx_sealed_data_t>()) - 1, 1},
-    )]
-    fn sealed_size_overflow(data_size: usize, aad_size: usize) {
-        assert_eq!(
-            SealedBuilder::<&[u8]>::check_sealed_size_overflow(data_size as u64, aad_size as u64),
-            Err(Error::DataAadOverflow {
-                data_size,
-                aad_size
-            })
-        );
-    }
-
-    #[test]
-    fn decrypted_text_len_short() {
-        let sgx_sealed_data = sgx_sealed_data_t::default();
-        let bytes = test_utils::sealed_data_to_bytes(sgx_sealed_data, b"short", Some(b"one"));
-        let data = Sealed::try_from(bytes.as_slice()).unwrap();
-        assert_eq!(data.decrypted_text_len(), Ok(5));
-    }
-
-    #[test]
-    fn decrypted_text_len_long() {
-        let sgx_sealed_data = sgx_sealed_data_t::default();
-        let bytes = test_utils::sealed_data_to_bytes(
-            sgx_sealed_data,
-            b"12345678901234567890",
-            Some(b"where"),
-        );
-        let data = Sealed::try_from(bytes.as_slice()).unwrap();
-        assert_eq!(data.decrypted_text_len(), Ok(20));
-    }
-}


### PR DESCRIPTION
Previously the `data` and `aad` values to the
`mc-sgx-tservicer::SealedBuilder` were only checked by the SGX SDK.
This resulted in a generic `InvalidParamter` error that had no context.
Now the `data` and `aad` values are ensured to be valid when they are
provided to the `SealedBuilder`.