### PR TITLE
Add explicit errors for failures to set_path

### DIFF
--- a/dcap/ql/src/lib.rs
+++ b/dcap/ql/src/lib.rs
@@ -22,6 +22,10 @@ pub enum Error {
     Sgx(Quote3Error),
     /// Failed ot convert a path to a string.  Path {0}
     PathStringConversion(String),
+    /// Path does not exist
+    PathDoesNotExist(String),
+    /// Path length is longer than the 259 character bytes allowed
+    PathLengthTooLong(String),
 }
 
 impl From<Quote3Error> for Error {


### PR DESCRIPTION
Previously `mc-sgx-ql::PathInitializer::with_paths` returned a generic
SGX InvalidParameter error when a parameter was invalid.  Now a more
specific error is returned saying what was wrong with the parameter.