### PR TITLE
`mc-sgx-dcap-ql` limits the enclave load policy to one call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `mc_sgx_tservice::SealError`, make `SealedBuilder` use it instead of
   `mc_sgx_core_types::Error`.
+- `mc-sgx-dcap-ql::set_path` and `mc-sgx-dcap-ql::load_policy` have been
+  replaced with `mc-sgx-dcap-ql::PathInitializer` and
+  `mc-sgx-dcap-ql::LoadPolicyInitializer`
   
 ## [0.2.1] - 2022-10-14
 

--- a/dcap/ql/src/lib.rs
+++ b/dcap/ql/src/lib.rs
@@ -10,7 +10,7 @@ mod quote_enclave;
 
 use mc_sgx_dcap_types::Quote3Error;
 pub use quote3::TryFromReport;
-pub use quote_enclave::{load_policy, PathInitializer, QeTargetInfo};
+pub use quote_enclave::{LoadPolicyInitializer, PathInitializer, QeTargetInfo};
 
 /// Errors interacting with quote library functions
 #[derive(Clone, Debug, displaydoc::Display, Eq, Hash, PartialEq, PartialOrd, Ord)]
@@ -26,6 +26,8 @@ pub enum Error {
     PathDoesNotExist(String),
     /// Path length is longer than the 259 character bytes allowed
     PathLengthTooLong(String),
+    /// The quoting enclave load policy has already been initialized
+    LoadPolicyInitialized,
 }
 
 impl From<Quote3Error> for Error {

--- a/dcap/ql/src/quote3.rs
+++ b/dcap/ql/src/quote3.rs
@@ -28,6 +28,7 @@ pub trait TryFromReport {
     /// Will return an [`Error::Sgx`] if there is a failure from the SGX SDK
     fn try_from_report(report: Report) -> Result<Quote3<Vec<u8>>, Error> {
         crate::PathInitializer::ensure_initialized()?;
+        crate::LoadPolicyInitializer::ensure_initialized()?;
 
         let mut size = 0;
         unsafe { mc_sgx_dcap_ql_sys::sgx_qe_get_quote_size(&mut size) }.into_result()?;


### PR DESCRIPTION
Previously the `mc-sgx-dcap-ql::load_policy()` could be called multiple
times during a process.  Now `mc-sgx-dcap-ql::PathInitializer::policy()`
can only be called once for the entire process run.