### PR TITLE
Add `mc-sgx-dcap-quoteverify::PathInitializer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,12 +497,15 @@ dependencies = [
 name = "mc-sgx-dcap-quoteverify"
 version = "0.3.0-beta.0"
 dependencies = [
+ "displaydoc",
  "mc-sgx-dcap-quoteverify-sys",
  "mc-sgx-dcap-quoteverify-sys-types",
  "mc-sgx-dcap-quoteverify-types",
  "mc-sgx-dcap-sys-types",
  "mc-sgx-dcap-types",
  "mc-sgx-util",
+ "once_cell",
+ "serial_test",
  "tempfile",
  "yare",
 ]

--- a/dcap/ql/src/lib.rs
+++ b/dcap/ql/src/lib.rs
@@ -20,7 +20,7 @@ pub enum Error {
     PathsInitialized,
     /// Error from SGX quoting library function: {0}
     Sgx(Quote3Error),
-    /// Failed ot convert a path to a string.  Path {0}
+    /// Failed to convert a path to a string.  Path {0}
     PathStringConversion(String),
     /// Path does not exist
     PathDoesNotExist(String),

--- a/dcap/ql/src/quote_enclave.rs
+++ b/dcap/ql/src/quote_enclave.rs
@@ -23,7 +23,8 @@ use std::{ffi::CString, os::unix::ffi::OsStrExt, path::Path, sync::Mutex};
 //  bytes (+ NULL), not the number of characters.
 const MAX_PATH_LENGTH: usize = 260;
 
-/// A convenience type alias for a `Result` which contains an [`Error`].
+/// A convenience type alias for a [`Result`](core::result::Result) which
+/// contains an [`Error`].
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Initialization of the paths for the quoting enclaves and quote provider
@@ -105,7 +106,7 @@ impl PathInitializer {
         }
     }
 
-    /// Will ensure the paths have been initialized
+    /// Ensures the paths have been initialized
     ///
     /// If the paths have not been initialized will initialize to the default.
     ///

--- a/dcap/quoteverify/Cargo.toml
+++ b/dcap/quoteverify/Cargo.toml
@@ -13,13 +13,16 @@ categories = ["api-bindings", "hardware-support"]
 keywords = ["sgx"]
 
 [dependencies]
+displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-dcap-quoteverify-sys = { path = "sys", version = "=0.3.0-beta.0" }
 mc-sgx-dcap-quoteverify-sys-types = { path = "sys/types", version = "=0.3.0-beta.0" }
 mc-sgx-dcap-quoteverify-types = { path = "types", version = "=0.3.0-beta.0" }
 mc-sgx-dcap-types = { path = "../types", version = "=0.3.0-beta.0" }
 mc-sgx-util = { path = "../../util", version = "=0.3.0-beta.0" }
+once_cell = "1.15.0"
 
 [dev-dependencies]
 mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.3.0-beta.0" }
+serial_test = { version = "0.9.0", default-features = false }
 tempfile = "3.3.0"
 yare = "1.0.1"

--- a/dcap/quoteverify/src/lib.rs
+++ b/dcap/quoteverify/src/lib.rs
@@ -18,7 +18,7 @@ pub enum Error {
     PathsInitialized,
     /// Error from SGX quoting library function: {0}
     Sgx(Quote3Error),
-    /// Failed ot convert a path to a string.  Path {0}
+    /// Failed to convert a path to a string.  Path {0}
     PathStringConversion(String),
     /// Path does not exist
     PathDoesNotExist(String),

--- a/dcap/quoteverify/src/lib.rs
+++ b/dcap/quoteverify/src/lib.rs
@@ -6,5 +6,30 @@
 mod quote_enclave;
 mod verify;
 
-pub use quote_enclave::{load_policy, set_path};
+use mc_sgx_dcap_types::Quote3Error;
+pub use quote_enclave::{load_policy, PathInitializer};
 pub use verify::supplemental_data_size;
+
+/// Errors interacting with quote verification library functions
+#[derive(Clone, Debug, displaydoc::Display, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Error {
+    /// Paths have already been initialized
+    PathsInitialized,
+    /// Error from SGX quoting library function: {0}
+    Sgx(Quote3Error),
+    /// Failed ot convert a path to a string.  Path {0}
+    PathStringConversion(String),
+    /// Path does not exist
+    PathDoesNotExist(String),
+    /// Path length is longer than the 259 character bytes allowed
+    PathLengthTooLong(String),
+    /// The quoting enclave load policy has already been initialized
+    LoadPolicyInitialized,
+}
+
+impl From<Quote3Error> for Error {
+    fn from(src: Quote3Error) -> Self {
+        Self::Sgx(src)
+    }
+}

--- a/dcap/quoteverify/src/quote_enclave.rs
+++ b/dcap/quoteverify/src/quote_enclave.rs
@@ -20,7 +20,8 @@ use std::{ffi::CString, os::unix::ffi::OsStrExt, path::Path, sync::Mutex};
 //  bytes (+ NULL), not the number of characters.
 const MAX_PATH_LENGTH: usize = 260;
 
-/// A convenience type alias for a `Result` which contains an [`Error`].
+/// A convenience type alias for a [`Result`](core::result::Result) which
+/// contains an [`Error`].
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Initialization of the paths for the quote verification enclave and quote
@@ -93,7 +94,7 @@ impl PathInitializer {
         }
     }
 
-    /// Will ensure the paths have been initialized
+    /// Ensures the paths have been initialized
     ///
     /// If the paths have not been initialized will initialize to the default.
     ///

--- a/dcap/quoteverify/src/quote_enclave.rs
+++ b/dcap/quoteverify/src/quote_enclave.rs
@@ -7,55 +7,181 @@
 //! has a mix up.  It uses the *verification* description for `sgx_ql_set_path`
 //! and the "generation" description for `sgx_qv_set_path`
 
-use mc_sgx_dcap_quoteverify_types::PathKind as QvPath;
-use mc_sgx_dcap_types::{Quote3Error, RequestPolicy};
+use crate::Error;
+use mc_sgx_dcap_quoteverify_types::PathKind;
+use mc_sgx_dcap_types::RequestPolicy;
 use mc_sgx_util::ResultInto;
-use std::{ffi::CString, os::unix::ffi::OsStrExt, path::Path};
+use once_cell::sync::Lazy;
+use std::{ffi::CString, os::unix::ffi::OsStrExt, path::Path, sync::Mutex};
 
-/// Set path for QVE(Quote verification enclave) or QPL(Quote provider library)
+// Using the value from SGX to validate inputs and provide better error
+// messages.
+// NB: This should be checked once converted to a CString as it's the number of
+//  bytes (+ NULL), not the number of characters.
+const MAX_PATH_LENGTH: usize = 260;
+
+/// A convenience type alias for a `Result` which contains an [`Error`].
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Initialization of the paths for the quote verification enclave and quote
+/// provider library
 ///
-/// This allows one to override the path that will be searched for each
-/// `path_type`.  When this isn't called then the local path and dlopen search
-/// path will be utilized.
-///
-/// Returns [`Quote3Error`] when
-/// * `path` does not point to a file
-/// * `path` is longer than 259 (bytes)
-/// * `path` contains a null (0) byte.
-///
-/// # Arguments
-/// * `path_type` - Which path to set
-/// * `path` - The path value to use.  This is the full path to a file.
-pub fn set_path<P: AsRef<Path>>(path_type: QvPath, path: P) -> Result<(), Quote3Error> {
-    let c_path = CString::new(path.as_ref().as_os_str().as_bytes())
-        .map_err(|_| Quote3Error::InvalidParameter)?;
-    unsafe { mc_sgx_dcap_quoteverify_sys::sgx_qv_set_path(path_type.into(), c_path.as_ptr()) }
-        .into_result()
+/// This should only be called once during process start up utilizing
+/// [`PathInitializer::with_paths()`] or [`PathInitializer::try_default()`].
+/// If a consumer of this crate does not explicitly initialize the paths, then
+/// they will be defaulted on the first call to an SGX function that needs the
+/// paths set.
+#[derive(Debug)]
+pub struct PathInitializer;
+
+static PATH_INITIALIZER: Lazy<Mutex<Option<PathInitializer>>> = Lazy::new(|| Mutex::new(None));
+
+impl PathInitializer {
+    /// Try to initialize the paths to the default for the system
+    ///
+    /// # Errors
+    /// * [`Error::PathsInitialized`] if the paths have been previously
+    ///   initialized.
+    /// * [`Error::Sgx`] if any of the default paths don't exist on the system.
+    pub fn try_default() -> Result<()> {
+        // SGX has internal defaults with fallbacks, so we pass `None` for both
+        // paths.
+        Self::with_paths(None::<&Path>, None::<&Path>)
+    }
+
+    /// Initialize the DCAP quote verification library paths with provided
+    /// values
+    ///
+    /// # Arguments
+    /// * `quote_verification_enclave` - The full file path to the quote
+    ///   verification enclave. If `None` then the default quote verification
+    ///   enclave, which is embedded in the quote verification library, will be
+    ///   used.
+    /// * `quote_provider_library` - The full file path to the quote provider
+    ///   library.  When this is `None` then the quote provider library found in
+    ///   the system path will be used.
+    ///
+    /// # Errors
+    /// * [`Error::PathsInitialized`] if the paths have been previously
+    ///   initialized.
+    /// * [`Error::PathStringConversion`] if one of the paths cannot be
+    ///   converted to a [`CString`]
+    /// * [`Error::Sgx`] if
+    ///     * one of the paths does not point to a file
+    ///     * one of the paths is longer than 259 (bytes)
+    ///     * one of the paths contains a null (0) byte.
+    pub fn with_paths<P1, P2>(
+        quote_verification_enclave: Option<P1>,
+        quote_provider_library: Option<P2>,
+    ) -> Result<()>
+    where
+        P1: AsRef<Path>,
+        P2: AsRef<Path>,
+    {
+        let mut value = PATH_INITIALIZER.lock().expect("Mutex has been poisoned");
+        if value.is_none() {
+            quote_verification_enclave.map_or(Ok(()), |path| {
+                Self::set_path(PathKind::QuoteVerificationEnclave, path)
+            })?;
+            quote_provider_library.map_or(Ok(()), |path| {
+                Self::set_path(PathKind::QuoteProviderLibrary, path)
+            })?;
+            *value = Some(PathInitializer);
+            Ok(())
+        } else {
+            Err(Error::PathsInitialized)
+        }
+    }
+
+    /// Will ensure the paths have been initialized
+    ///
+    /// If the paths have not been initialized will initialize to the default.
+    ///
+    /// # Errors
+    /// Will return [`Error::Sgx`] if the paths have not been initialized and
+    /// the default paths don't exist.
+    ///
+    /// Will *not* return an error if the paths were previously initialized.
+    pub(crate) fn ensure_initialized() -> Result<()> {
+        match Self::try_default() {
+            Ok(_) | Err(Error::PathsInitialized) => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Set path for QVE(Quoting Verification Enclave) or
+    /// QPL(Quote Provider Library)
+    ///
+    /// This allows one to override the path that will be searched for each
+    /// `path_kind`.  When this isn't called then the local path and dlopen
+    /// search path will be utilized.
+    ///
+    /// # Arguments
+    /// * `path_kind` - Which path to set
+    /// * `path` - The path value to use.  This is the full path to a file.
+    ///
+    /// # Errors
+    /// * [`Error::PathStringConversion`] if `path_kind` cannot be converted to
+    ///   a [`CString`]
+    /// * [`Error::Sgx`] if
+    ///     * `path` does not point to a file
+    ///     * `path` is longer than 259 (bytes)
+    ///     * `path` contains a null (0) byte.
+    fn set_path<P: AsRef<Path>>(path_kind: PathKind, path: P) -> Result<()> {
+        let path = path.as_ref();
+        let c_path = CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| Error::PathStringConversion(path.to_string_lossy().into_owned()))?;
+
+        path.is_file()
+            .then_some(true)
+            .ok_or_else(|| Error::PathDoesNotExist(path.to_string_lossy().into_owned()))?;
+
+        if c_path.as_bytes_with_nul().len() > MAX_PATH_LENGTH {
+            return Err(Error::PathLengthTooLong(
+                path.to_string_lossy().into_owned(),
+            ));
+        }
+
+        unsafe { mc_sgx_dcap_quoteverify_sys::sgx_qv_set_path(path_kind.into(), c_path.as_ptr()) }
+            .into_result()?;
+        Ok(())
+    }
 }
 
 /// Set the load policy
 ///
 /// # Arguments
 /// * `policy` - The policy to use for loading quoting enclaves
-pub fn load_policy(policy: RequestPolicy) -> Result<(), Quote3Error> {
+pub fn load_policy(policy: RequestPolicy) -> Result<()> {
     unsafe { mc_sgx_dcap_quoteverify_sys::sgx_qv_set_enclave_load_policy(policy.into()) }
-        .into_result()
+        .into_result()?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use mc_sgx_dcap_quoteverify_types::PathKind::{QuoteProviderLibrary, QuoteVerificationEnclave};
+    use serial_test::serial;
     use std::fs;
     use tempfile::tempdir;
     use yare::parameterized;
+
+    /// Resets the [`PATH_INITIALIZER`] to being uninitialized.
+    /// Since there is *one* [`PATH_INITIALIZER`] for the entire test process
+    /// any tests focusing on the functionality of the [`PATH_INITIALIZER`]
+    /// should be utilizing the `#[serial]` macro.
+    fn reset_path_initializer() {
+        let mut value = PATH_INITIALIZER.lock().expect("Mutex has been poisoned");
+        *value = None;
+    }
 
     #[test]
     fn qve_path_succeeds() {
         let dir = tempdir().unwrap();
         let file_name = dir.path().join("fake.txt");
         fs::write(&file_name, "stuff").unwrap();
-        assert!(set_path(QuoteVerificationEnclave, file_name).is_ok());
+        assert!(PathInitializer::set_path(QuoteVerificationEnclave, file_name).is_ok());
     }
 
     #[test]
@@ -63,13 +189,13 @@ mod test {
         let dir = tempdir().unwrap();
         let file_name = dir.path().join("fake.txt");
         fs::write(&file_name, "stuff").unwrap();
-        assert!(set_path(QuoteProviderLibrary, file_name).is_ok());
+        assert!(PathInitializer::set_path(QuoteProviderLibrary, file_name).is_ok());
     }
 
     #[test]
     fn path_as_directory_fails() {
         let dir = tempdir().unwrap();
-        assert!(set_path(QuoteVerificationEnclave, dir.path()).is_err());
+        assert!(PathInitializer::set_path(QuoteVerificationEnclave, dir.path()).is_err());
     }
 
     #[test]
@@ -78,7 +204,7 @@ mod test {
         let file_name = dir.path().join("fake\0.txt");
         // fs::write() will fail to create the file with a null byte in the path
         // so we pass the path as non existent to `set_path`.
-        assert!(set_path(QuoteVerificationEnclave, file_name).is_err());
+        assert!(PathInitializer::set_path(QuoteVerificationEnclave, file_name).is_err());
     }
 
     #[test]
@@ -92,7 +218,7 @@ mod test {
         let file_name = dir.path().join(long_name);
         fs::write(&file_name, "stuff").unwrap();
 
-        assert!(set_path(QuoteProviderLibrary, file_name).is_ok());
+        assert!(PathInitializer::set_path(QuoteProviderLibrary, file_name).is_ok());
     }
 
     #[test]
@@ -106,7 +232,115 @@ mod test {
         let file_name = dir.path().join(long_name);
         fs::write(&file_name, "stuff").unwrap();
 
-        assert!(set_path(QuoteProviderLibrary, file_name).is_err());
+        assert!(PathInitializer::set_path(QuoteProviderLibrary, file_name).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn default_path_initializer_succeeds() {
+        reset_path_initializer();
+        let result = PathInitializer::try_default();
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    #[serial]
+    fn default_path_initializer_fails_when_already_initialized() {
+        reset_path_initializer();
+        PathInitializer::try_default().unwrap();
+        let result = PathInitializer::try_default();
+        assert_eq!(result, Err(Error::PathsInitialized));
+    }
+
+    #[test]
+    #[serial]
+    fn with_paths_path_initializer_succeeds() {
+        let dir = tempdir().unwrap();
+        let names = ["1", "2"]
+            .into_iter()
+            .map(|name| {
+                let file_name = dir.path().join(name);
+                fs::write(&file_name, name).unwrap();
+                file_name
+            })
+            .collect::<Vec<_>>();
+
+        reset_path_initializer();
+        let result = PathInitializer::with_paths(Some(&names[0]), Some(&names[1]));
+        assert_eq!(result, Ok(()));
+    }
+
+    #[test]
+    #[serial]
+    fn with_paths_after_default_fails() {
+        let dir = tempdir().unwrap();
+        let names = ["1", "2"]
+            .into_iter()
+            .map(|name| {
+                let file_name = dir.path().join(name);
+                fs::write(&file_name, name).unwrap();
+                file_name
+            })
+            .collect::<Vec<_>>();
+
+        reset_path_initializer();
+        PathInitializer::try_default().unwrap();
+        let result = PathInitializer::with_paths(Some(&names[0]), Some(&names[1]));
+        assert_eq!(result, Err(Error::PathsInitialized));
+    }
+
+    #[test]
+    #[serial]
+    fn with_paths_more_than_once_fails() {
+        let dir = tempdir().unwrap();
+        let names = ["a", "b"]
+            .into_iter()
+            .map(|name| {
+                let file_name = dir.path().join(name);
+                fs::write(&file_name, name).unwrap();
+                file_name
+            })
+            .collect::<Vec<_>>();
+
+        reset_path_initializer();
+        PathInitializer::with_paths(Some(&names[0]), Some(&names[1])).unwrap();
+        let result = PathInitializer::with_paths(Some(&names[0]), Some(&names[1]));
+        assert_eq!(result, Err(Error::PathsInitialized));
+    }
+
+    #[test]
+    #[serial]
+    fn bad_path_fails_and_can_be_retried() {
+        const MAX_PATH: usize = 259;
+        let dir = tempdir().unwrap();
+        let mut dir_length = dir.path().as_os_str().as_bytes().len();
+        dir_length += 1; // for the joining "/"
+        let long_name = str::repeat("a", (MAX_PATH + 1) - dir_length);
+        let mut names = [&long_name, "b"]
+            .into_iter()
+            .map(|name| {
+                let file_name = dir.path().join(name);
+                fs::write(&file_name, name).unwrap();
+                file_name
+            })
+            .collect::<Vec<_>>();
+
+        for _ in 0..names.len() {
+            names.rotate_right(1);
+            reset_path_initializer();
+            let result = PathInitializer::with_paths(Some(&names[0]), Some(&names[1]));
+            assert!(matches!(result, Err(Error::PathLengthTooLong(_))));
+
+            assert_eq!(PathInitializer::try_default(), Ok(()));
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn ensuring_paths_initialized_succeeds_when_already_initialized() {
+        reset_path_initializer();
+        PathInitializer::try_default().unwrap();
+        assert_eq!(PathInitializer::ensure_initialized(), Ok(()));
     }
 
     #[parameterized(

--- a/dcap/quoteverify/src/verify.rs
+++ b/dcap/quoteverify/src/verify.rs
@@ -1,12 +1,13 @@
 // Copyright (c) 2022 MobileCoin Foundation
 
-//! This module contains logic to verify a DCAP quote
+//! This module contains logic to assist in verifying a DCAP quote
 
-use mc_sgx_dcap_types::Quote3Error;
+use crate::{Error, PathInitializer};
 use mc_sgx_util::ResultInto;
 
 /// Get the supplemental data size
-pub fn supplemental_data_size() -> Result<usize, Quote3Error> {
+pub fn supplemental_data_size() -> Result<usize, Error> {
+    PathInitializer::ensure_initialized()?;
     let mut size: u32 = 0;
     unsafe { mc_sgx_dcap_quoteverify_sys::sgx_qv_get_quote_supplemental_data_size(&mut size) }
         .into_result()?;


### PR DESCRIPTION
Previously the quote verification enclave and quote provider library
paths for `mc-sgx-dcap-quoteverify` were set via
`mc-sgx-dcap-quoteverify::set_path`.  Now there is a one time entry
point of `mc-sgx-dcap-quoteverify::PathInitiliazer` to set the paths.