### PR TITLE
Ensure types crates don't use alloc with CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -244,6 +244,33 @@ jobs:
         with:
           files: lcov.info
 
+  build-no-alloc:
+    runs-on: ubuntu-20.04
+    needs:
+      - "rustfmt"
+      - "markdown-lint"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/sgxsdk
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+      - uses: r7kamura/rust-problem-matchers@v1
+      - name: Build types with no alloc crate
+        # Some notes on this build command:
+        # - The vendored headers are used to get the necessary DCAP headers
+        # - The installed `tlibc` is used to get a compilable `time.h` for the target.
+        # - In the unlikely event that `thumbv7m-none-eabi` was installed with rustup, this would error out with
+        #   duplicate core symbols due to `-Z build-std=core`.
+        run: |
+          cargo metadata --no-deps --format-version=1 |  \
+            jq -r '.packages[].name' | \
+            grep -e types | \
+            xargs -n1 sh -c 'CFLAGS="-isystem${GITHUB_WORKSPACE}/core/build/headers -isystem/opt/intel/sgxsdk/include/tlibc" cargo build -Z build-std=core --target thumbv7m-none-eabi -p $0 || exit 255'
+
   notify:
     runs-on: ubuntu-latest
     if: failure() && ${{ github.event_name }} == 'push'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -251,7 +251,6 @@ jobs:
       - "markdown-lint"
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/sgxsdk
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -262,14 +261,14 @@ jobs:
       - name: Build types with no alloc crate
         # Some notes on this build command:
         # - The vendored headers are used to get the necessary DCAP headers
-        # - The installed `tlibc` is used to get a compilable `time.h` for the target.
+        # - The vendored `tlibc` is used to get a compilable `time.h` for the target.
         # - In the unlikely event that `thumbv7m-none-eabi` was installed with rustup, this would error out with
         #   duplicate core symbols due to `-Z build-std=core`.
         run: |
           cargo metadata --no-deps --format-version=1 |  \
             jq -r '.packages[].name' | \
             grep -e types | \
-            xargs -n1 sh -c 'CFLAGS="-isystem${GITHUB_WORKSPACE}/core/build/headers -isystem/opt/intel/sgxsdk/include/tlibc" cargo build -Z build-std=core --target thumbv7m-none-eabi -p $0 || exit 255'
+            xargs -n1 sh -c 'CFLAGS="-isystem${GITHUB_WORKSPACE}/core/build/headers -isystem${GITHUB_WORKSPACE}/core/build/headers/tlibc" cargo build -Z build-std=core --target thumbv7m-none-eabi -p $0 || exit 255'
 
   notify:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ version = "0.3.1-beta.0"
 dependencies = [
  "bitflags",
  "displaydoc",
+ "getrandom",
  "mc-sgx-core-sys-types",
  "mc-sgx-util",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,14 @@ exclude = [
     "test_enclave",
 ]
 
+# We need to explicitly specify resolver 2.
+# We shouldn't have to per https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html, however if you
+# remove this, `getrandom` will fail trying to find `std` when building `mc-sgx-core-types`.  This is because
+# `mc-sgx-core-types` uses `rand` in it's `dev-dependencies`.  `rand` will use the `std` feature of `getrandom`, however
+# being in `dev-dependencies` it shouldn't normally get pulled in during a build.
+# Even specifying `edition = "2021"` here will not fix this
+resolver = "2"
+
 [profile.dev]
 opt-level = 0
 lto = true

--- a/core/build/README.md
+++ b/core/build/README.md
@@ -9,6 +9,30 @@
 
 Utilities for compiling FFI wrappers to SGX libraries.
 
+## Environment Variables
+
+Below are environment variables that affect the building of the SGX FFI
+wrappers.
+
+- `SGX_SDK` The path to the Intel SGX SDK. Provides:
+  
+  1. The location of the SGX SDK headers.
+  
+     Note: the DCAP headers are assumed to be in the default system include path
+  2. The location of the SGX SDK libraries for linking
+  
+  When `SGX_SDK` is not set:
+
+  1. The vendored local directory `headers/` will be used for compile time
+     includes
+  2. `/opt/intel/sgxsdk` will be used as the linking directory for SGX SDK
+     libraries
+
+- `CFLAGS` - Used when generating the rust bindings. Useful to specify
+  system include paths. Multiple arguments can be separated with whitespace.
+  This does **not** support escaped whitespace as specified in
+  <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html>
+
 [crate-image]: https://img.shields.io/crates/v/mc-sgx-core-build.svg?style=flat-square
 [crate-link]: https://crates.io/crates/mc-sgx-core-build
 [license-image]: https://img.shields.io/crates/l/mc-sgx-core-build?style=flat-square

--- a/core/build/headers/tlibc/assert.h
+++ b/core/build/headers/tlibc/assert.h
@@ -1,0 +1,63 @@
+/*	$OpenBSD: assert.h,v 1.12 2006/01/31 10:53:51 hshoexer Exp $	*/
+/*	$NetBSD: assert.h,v 1.6 1994/10/26 00:55:44 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1992, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)assert.h	8.2 (Berkeley) 1/21/94
+ */
+
+/*
+ * Unlike other ANSI header files, <assert.h> may usefully be included
+ * multiple times, with and without NDEBUG defined.
+ */
+
+#include <sys/cdefs.h>
+
+#undef assert
+
+#ifdef NDEBUG
+# define assert(e) ((void)0)
+#else
+# define assert(e) ((e) ? (void)0 : __assert(__FILE__, __LINE__, __func__, #e))
+#endif
+
+#ifndef _ASSERT_H_DECLS
+#define _ASSERT_H_DECLS
+__BEGIN_DECLS
+
+void _TLIBC_CDECL_ __assert(const char *, int, const char *, const char *);
+
+__END_DECLS
+#endif /* Not _ASSERT_H_DECLS */
+

--- a/core/build/headers/tlibc/ctype.h
+++ b/core/build/headers/tlibc/ctype.h
@@ -1,0 +1,65 @@
+/*	$OpenBSD: ctype.h,v 1.22 2010/10/01 20:10:24 guenther Exp $	*/
+/*	$NetBSD: ctype.h,v 1.14 1994/10/26 00:55:47 cgd Exp $	*/
+
+/*
+ * Copyright (c) 1989 The Regents of the University of California.
+ * All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)ctype.h	5.3 (Berkeley) 4/3/91
+ */
+
+#ifndef _CTYPE_H_
+#define _CTYPE_H_
+
+#include <sys/cdefs.h>
+
+__BEGIN_DECLS
+
+int _TLIBC_CDECL_ isalnum(int);
+int _TLIBC_CDECL_ isalpha(int);
+int _TLIBC_CDECL_ iscntrl(int);
+int _TLIBC_CDECL_ isdigit(int);
+int _TLIBC_CDECL_ isgraph(int);
+int _TLIBC_CDECL_ islower(int);
+int _TLIBC_CDECL_ isprint(int);
+int _TLIBC_CDECL_ ispunct(int);
+int _TLIBC_CDECL_ isspace(int);
+int _TLIBC_CDECL_ isupper(int);
+int _TLIBC_CDECL_ isxdigit(int);
+int _TLIBC_CDECL_ tolower(int);
+int _TLIBC_CDECL_ toupper(int);
+int _TLIBC_CDECL_ isblank(int);
+int _TLIBC_CDECL_ isascii(int);
+
+__END_DECLS
+
+#endif /* _CTYPE_H_ */

--- a/core/build/headers/tlibc/endian.h
+++ b/core/build/headers/tlibc/endian.h
@@ -1,0 +1,33 @@
+/*	$OpenBSD: endian.h,v 1.18 2006/03/27 07:09:24 otto Exp $	*/
+
+/*-
+ * Copyright (c) 1997 Niklas Hallqvist.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ENDIAN_H_
+#define _ENDIAN_H_
+
+#include <sys/endian.h>
+
+#endif /* _ENDIAN_H_ */
+

--- a/core/build/headers/tlibc/errno.h
+++ b/core/build/headers/tlibc/errno.h
@@ -1,0 +1,187 @@
+/*	$OpenBSD: errno.h,v 1.1 2005/12/28 16:33:56 millert Exp $	*/
+
+/*
+ * Copyright (c) 1982, 1986, 1989, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)errno.h	8.5 (Berkeley) 1/21/94
+ */
+
+#ifndef	_ERRNO_H_
+#define	_ERRNO_H_
+
+#include <sys/cdefs.h>
+
+#define EPERM 1
+#define ENOENT 2
+#define ESRCH 3
+#define EINTR 4
+#define EIO 5
+#define ENXIO 6
+#define E2BIG 7
+#define ENOEXEC 8
+#define EBADF 9
+#define ECHILD 10
+#define EAGAIN 11
+#define ENOMEM 12
+#define EACCES 13
+#define EFAULT 14
+#define ENOTBLK 15
+#define EBUSY 16
+#define EEXIST 17
+#define EXDEV 18
+#define ENODEV 19
+#define ENOTDIR 20
+#define EISDIR 21
+#define EINVAL 22
+#define ENFILE 23
+#define EMFILE 24
+#define ENOTTY 25
+#define ETXTBSY 26
+#define EFBIG 27
+#define ENOSPC 28
+#define ESPIPE 29
+#define EROFS 30
+#define EMLINK 31
+#define EPIPE 32
+#define EDOM 33
+#define ERANGE 34
+#define EDEADLK 35
+#define ENAMETOOLONG 36
+#define ENOLCK 37
+#define ENOSYS 38
+#define ENOTEMPTY 39
+#define ELOOP 40
+#define EWOULDBLOCK EAGAIN
+#define ENOMSG 42
+#define EIDRM 43
+#define ECHRNG 44
+#define EL2NSYNC 45
+#define EL3HLT 46
+#define EL3RST 47
+#define ELNRNG 48
+#define EUNATCH 49
+#define ENOCSI 50
+#define EL2HLT 51
+#define EBADE 52
+#define EBADR 53
+#define EXFULL 54
+#define ENOANO 55
+#define EBADRQC 56
+#define EBADSLT 57
+#define EDEADLOCK EDEADLK
+#define EBFONT 59
+#define ENOSTR 60
+#define ENODATA 61
+#define ETIME 62
+#define ENOSR 63
+#define ENONET 64
+#define ENOPKG 65
+#define EREMOTE 66
+#define ENOLINK 67
+#define EADV 68
+#define ESRMNT 69
+#define ECOMM 70
+#define EPROTO 71
+#define EMULTIHOP 72
+#define EDOTDOT 73
+#define EBADMSG 74
+#define EOVERFLOW 75
+#define ENOTUNIQ 76
+#define EBADFD 77
+#define EREMCHG 78
+#define ELIBACC 79
+#define ELIBBAD 80
+#define ELIBSCN 81
+#define ELIBMAX 82
+#define ELIBEXEC 83
+#define EILSEQ 84
+#define ERESTART 85
+#define ESTRPIPE 86
+#define EUSERS 87
+#define ENOTSOCK 88
+#define EDESTADDRREQ 89
+#define EMSGSIZE 90
+#define EPROTOTYPE 91
+#define ENOPROTOOPT 92
+#define EPROTONOSUPPORT 93
+#define ESOCKTNOSUPPORT 94
+#define EOPNOTSUPP 95
+#define EPFNOSUPPORT 96
+#define EAFNOSUPPORT 97
+#define EADDRINUSE 98
+#define EADDRNOTAVAIL 99
+#define ENETDOWN 100
+#define ENETUNREACH 101
+#define ENETRESET 102
+#define ECONNABORTED 103
+#define ECONNRESET 104
+#define ENOBUFS 105
+#define EISCONN 106
+#define ENOTCONN 107
+#define ESHUTDOWN 108
+#define ETOOMANYREFS 109
+#define ETIMEDOUT 110
+#define ECONNREFUSED 111
+#define EHOSTDOWN 112
+#define EHOSTUNREACH 113
+#define EALREADY 114
+#define EINPROGRESS 115
+#define ESTALE 116
+#define EUCLEAN 117
+#define ENOTNAM 118
+#define ENAVAIL 119
+#define EISNAM 120
+#define EREMOTEIO 121
+#define EDQUOT 122
+#define ENOMEDIUM 123
+#define EMEDIUMTYPE 124
+#define ECANCELED 125
+#define ENOKEY 126
+#define EKEYEXPIRED 127
+#define EKEYREVOKED 128
+#define EKEYREJECTED 129
+#define EOWNERDEAD 130
+#define ENOTRECOVERABLE 131
+#define ERFKILL 132
+#define EHWPOISON 133
+#define ENOTSUP EOPNOTSUPP
+
+__BEGIN_DECLS
+
+#ifndef errno
+int * _TLIBC_CDECL_ __errno(void);
+#define	errno (*__errno())
+#endif /* errno */
+__END_DECLS
+
+#endif /* _ERRNO_H_ */

--- a/core/build/headers/tlibc/float.h
+++ b/core/build/headers/tlibc/float.h
@@ -1,0 +1,84 @@
+/* $OpenBSD: float.h,v 1.3 2008/07/21 20:50:54 martynas Exp $ */
+/* $NetBSD: float.h,v 1.8 1995/06/20 20:45:37 jtc Exp $ */
+
+/*
+ * Copyright (c) 1989 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * @(#)float.h 7.1 (Berkeley) 5/8/90
+ */
+
+#ifndef _FLOAT_H_
+#define _FLOAT_H_
+
+#include <sys/cdefs.h>
+
+#define FLT_RADIX       2        /* b */
+
+// The rounding direction can be specified by fesetround() in <fenv.h>
+#define FLT_ROUNDS      1        /* addition rounding: near */
+#define DECIMAL_DIG     21       /* max precision in decimal digits */
+
+// NOTE: FLT_EVAL_METHOD is -1 under FREEBSD x86. 
+#ifdef __i386__
+#define FLT_EVAL_METHOD 2        /* long double */
+#else
+#define FLT_EVAL_METHOD 0        /* no promotions */
+#endif
+
+#define DBL_MANT_DIG    53
+#define DBL_EPSILON     2.2204460492503131E-16
+#define DBL_DIG         15
+#define DBL_MIN_EXP     (-1021)
+#define DBL_MIN         2.2250738585072014E-308
+#define DBL_MIN_10_EXP  (-307)
+#define DBL_MAX_EXP     1024
+#define DBL_MAX_10_EXP  308
+
+#define FLT_MANT_DIG    24                      /* p */
+#define FLT_DIG         6                       /* floor((p-1)*log10(b))+(b == 10) */
+#define FLT_MIN_EXP     (-125)                  /* emin */
+#define FLT_MIN_10_EXP  (-37)                   /* ceil(log10(b**(emin-1))) */
+#define FLT_MAX_EXP     128                     /* emax */
+#define FLT_MAX_10_EXP  38                      /* floor(log10((1-b**(-p))*b**emax)) */
+
+#define DBL_MAX         1.7976931348623157E+308
+#define FLT_EPSILON     1.19209290E-07F         /* b**(1-p) */
+#define FLT_MIN         1.17549435E-38F         /* b**(emin-1) */
+#define FLT_MAX         3.40282347E+38F         /* (1-b**(-p))*b**emax */
+
+#define LDBL_MANT_DIG   64
+#define LDBL_EPSILON    1.08420217248550443401e-19L
+#define LDBL_DIG        18
+#define LDBL_MIN_EXP    (-16381)
+#define LDBL_MIN        3.36210314311209350626e-4932L
+#define LDBL_MIN_10_EXP (-4931)
+#define LDBL_MAX_EXP    16384
+#define LDBL_MAX        1.18973149535723176502e+4932L
+#define LDBL_MAX_10_EXP 4932
+
+#endif  /* _FLOAT_H_ */

--- a/core/build/headers/tlibc/inttypes.h
+++ b/core/build/headers/tlibc/inttypes.h
@@ -1,0 +1,330 @@
+/*  $OpenBSD: inttypes.h,v 1.10 2009/01/13 18:13:51 kettenis Exp $  */
+
+/*
+ * Copyright (c) 1997, 2005 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _INTTYPES_H_
+#define _INTTYPES_H_
+
+#include <sys/stdint.h>
+
+/*
+ * 7.8.1 Macros for format specifiers
+ *
+ * Each of the following object-like macros expands to a string
+ * literal containing a conversion specifier, possibly modified by
+ * a prefix such as hh, h, l, or ll, suitable for use within the
+ * format argument of a formatted input/output function when
+ * converting the corresponding integer type.  These macro names
+ * have the general form of PRI (character string literals for the
+ * fprintf family) or SCN (character string literals for the fscanf
+ * family), followed by the conversion specifier, followed by a
+ * name corresponding to a similar typedef name.  For example,
+ * PRIdFAST32 can be used in a format string to print the value of
+ * an integer of type int_fast32_t.
+ */
+
+/* fprintf macros for signed integers */
+#define PRId8           "d"     /* int8_t */
+#define PRId16          "d"     /* int16_t */
+#define PRId32          "d"     /* int32_t */
+#ifdef __x86_64__
+#define PRId64          "ld"    /* int64_t */
+#else
+#define PRId64          "lld"   /* int64_t */
+#endif
+
+#define PRIdLEAST8      "d"     /* int_least8_t */
+#define PRIdLEAST16     "d"     /* int_least16_t */
+#define PRIdLEAST32     "d"     /* int_least32_t */
+#ifdef __x86_64__
+#define PRIdLEAST64     "ld"    /* int_least64_t */
+#else
+#define PRIdLEAST64     "lld"   /* int_least64_t */
+#endif
+
+#define PRIdFAST8       "d"     /* int_fast8_t */
+#ifdef __x86_64__
+#define PRIdFAST16      "ld"    /* int_fast16_t */
+#define PRIdFAST32      "ld"    /* int_fast32_t */
+#define PRIdFAST64      "ld"    /* int_fast64_t */
+#else
+#define PRIdFAST16      "d"     /* int_fast16_t */
+#define PRIdFAST32      "d"     /* int_fast32_t */
+#define PRIdFAST64      "lld"   /* int_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIdMAX         "ld"    /* intmax_t */
+#else
+#if defined(__i386__) 
+#define PRIdMAX         "lld"   /* intmax_t */
+#else
+#define PRIdMAX         "jd"    /* intmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIdPTR         "d"     /* intptr_t */
+#else
+#define PRIdPTR         "ld"    /* intptr_t */
+#endif
+
+#define PRIi8           "i"     /* int8_t */
+#define PRIi16          "i"     /* int16_t */
+#define PRIi32          "i"     /* int32_t */
+#ifdef __x86_64__
+#define PRIi64          "li"    /* int64_t */
+#else
+#define PRIi64          "lli"   /* int64_t */
+#endif
+
+#define PRIiLEAST8      "i"     /* int_least8_t */
+#define PRIiLEAST16     "i"     /* int_least16_t */
+#define PRIiLEAST32     "i"     /* int_least32_t */
+#ifdef __x86_64__
+#define PRIiLEAST64     "li"    /* int_least64_t */
+#else
+#define PRIiLEAST64     "lli"   /* int_least64_t */
+#endif
+
+#define PRIiFAST8       "i"     /* int_fast8_t */
+#ifdef __x86_64__
+#define PRIiFAST16      "li"    /* int_fast16_t */
+#define PRIiFAST32      "li"    /* int_fast32_t */
+#define PRIiFAST64      "li"    /* int_fast64_t */
+#else
+#define PRIiFAST16      "i"     /* int_fast16_t */
+#define PRIiFAST32      "i"     /* int_fast32_t */
+#define PRIiFAST64      "lli"   /* int_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIiMAX         "li"    /* intmax_t */
+#else
+#if defined(__i386__) 
+#define PRIiMAX         "lli"   /* intmax_t */
+#else
+#define PRIiMAX         "ji"    /* intmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIiPTR         "i"     /* intptr_t */
+#else
+#define PRIiPTR         "li"    /* intptr_t */
+#endif
+
+/* fprintf macros for unsigned integers */
+#define PRIo8           "o"     /* int8_t */
+#define PRIo16          "o"     /* int16_t */
+#define PRIo32          "o"     /* int32_t */
+#ifdef __x86_64__
+#define PRIo64          "lo"    /* int64_t */
+#else
+#define PRIo64          "llo"   /* int64_t */
+#endif
+
+#define PRIoLEAST8      "o"     /* int_least8_t */
+#define PRIoLEAST16     "o"     /* int_least16_t */
+#define PRIoLEAST32     "o"     /* int_least32_t */
+#ifdef __x86_64__
+#define PRIoLEAST64     "lo"    /* int_least64_t */
+#else
+#define PRIoLEAST64     "llo"   /* int_least64_t */
+#endif
+
+#define PRIoFAST8       "o"     /* int_fast8_t */
+#ifdef __x86_64__
+#define PRIoFAST16      "lo"    /* int_fast16_t */
+#define PRIoFAST32      "lo"    /* int_fast32_t */
+#define PRIoFAST64      "lo"    /* int_fast64_t */
+#else
+#define PRIoFAST16      "o"     /* int_fast16_t */
+#define PRIoFAST32      "o"     /* int_fast32_t */
+#define PRIoFAST64      "llo"   /* int_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIoMAX         "lo"    /* intmax_t */
+#else
+#if defined(__i386__) 
+#define PRIoMAX         "llo"   /* intmax_t */
+#else
+#define PRIoMAX         "jo"    /* intmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIoPTR         "o"     /* intptr_t */
+#else
+#define PRIoPTR         "lo"    /* intptr_t */
+#endif
+
+#define PRIu8           "u"     /* uint8_t */
+#define PRIu16          "u"     /* uint16_t */
+#define PRIu32          "u"     /* uint32_t */
+
+#ifdef __x86_64__
+#define PRIu64          "lu"    /* uint64_t */
+#else
+#define PRIu64          "llu"   /* uint64_t */
+#endif
+
+#define PRIuLEAST8      "u"     /* uint_least8_t */
+#define PRIuLEAST16     "u"     /* uint_least16_t */
+#define PRIuLEAST32     "u"     /* uint_least32_t */
+
+#ifdef __x86_64__
+#define PRIuLEAST64     "lu"    /* uint_least64_t */
+#else
+#define PRIuLEAST64     "llu"   /* uint_least64_t */
+#endif
+
+#define PRIuFAST8       "u"     /* uint_fast8_t */
+
+#ifdef __x86_64__
+#define PRIuFAST16      "lu"    /* uint_fast16_t */
+#define PRIuFAST32      "lu"    /* uint_fast32_t */
+#define PRIuFAST64      "lu"    /* uint_fast64_t */
+#else
+#define PRIuFAST16      "u"     /* uint_fast16_t */
+#define PRIuFAST32      "u"     /* uint_fast32_t */
+#define PRIuFAST64      "llu"   /* uint_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIuMAX         "lu"    /* uintmax_t */
+#else
+#if defined(__i386__) 
+#define PRIuMAX         "llu"   /* uintmax_t */
+#else
+#define PRIuMAX         "ju"    /* uintmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIuPTR         "u"     /* uintptr_t */
+#else
+#define PRIuPTR         "lu"    /* uintptr_t */
+#endif
+
+#define PRIx8           "x"     /* uint8_t */
+#define PRIx16          "x"     /* uint16_t */
+#define PRIx32          "x"     /* uint32_t */
+#ifdef __x86_64__
+#define PRIx64          "lx"    /* uint64_t */
+#else
+#define PRIx64          "llx"   /* uint64_t */
+#endif
+
+#define PRIxLEAST8      "x"     /* uint_least8_t */
+#define PRIxLEAST16     "x"     /* uint_least16_t */
+#define PRIxLEAST32     "x"     /* uint_least32_t */
+#ifdef __x86_64__
+#define PRIxLEAST64     "lx"    /* uint_least64_t */
+#else
+#define PRIxLEAST64     "llx"   /* uint_least64_t */
+#endif
+
+#define PRIxFAST8       "x"     /* uint_fast8_t */
+#ifdef __x86_64__
+#define PRIxFAST16      "lx"    /* uint_fast16_t */
+#define PRIxFAST32      "lx"    /* uint_fast32_t */
+#define PRIxFAST64      "lx"    /* uint_fast64_t */
+#else
+#define PRIxFAST16      "x"     /* uint_fast16_t */
+#define PRIxFAST32      "x"     /* uint_fast32_t */
+#define PRIxFAST64      "llx"   /* uint_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIxMAX         "lx"    /* uintmax_t */
+#else
+#if defined(__i386__) 
+#define PRIxMAX         "llx"   /* uintmax_t */
+#else
+#define PRIxMAX         "jx"    /* uintmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIxPTR         "x"     /* uintptr_t */
+#else
+#define PRIxPTR         "lx"    /* uintptr_t */
+#endif
+
+#define PRIX8           "X"     /* uint8_t */
+#define PRIX16          "X"     /* uint16_t */
+#define PRIX32          "X"     /* uint32_t */
+
+#ifdef __x86_64__
+#define PRIX64          "lX"    /* uint64_t */
+#else
+#define PRIX64          "llX"   /* uint64_t */
+#endif
+
+#define PRIXLEAST8      "X"     /* uint_least8_t */
+#define PRIXLEAST16     "X"     /* uint_least16_t */
+#define PRIXLEAST32     "X"     /* uint_least32_t */
+#ifdef __x86_64__
+#define PRIXLEAST64     "lX"    /* uint_least64_t */
+#else
+#define PRIXLEAST64     "llX"   /* uint_least64_t */
+#endif
+
+#define PRIXFAST8       "X"     /* uint_fast8_t */
+#ifdef __x86_64__
+#define PRIXFAST16      "lX"    /* uint_fast16_t */
+#define PRIXFAST32      "lX"    /* uint_fast32_t */
+#define PRIXFAST64      "lX"    /* uint_fast64_t */
+#else
+#define PRIXFAST16      "X"     /* uint_fast16_t */
+#define PRIXFAST32      "X"     /* uint_fast32_t */
+#define PRIXFAST64      "llX"   /* uint_fast64_t */
+#endif
+
+#ifdef __x86_64__
+#define PRIXMAX         "lX"    /* uintmax_t */
+#else
+#if defined(__i386__) 
+#define PRIXMAX         "llX"   /* uintmax_t */
+#else
+#define PRIXMAX         "jX"    /* uintmax_t */
+#endif
+#endif
+
+#ifdef __i386__
+#define PRIXPTR         "X"     /* uintptr_t */
+#else
+#define PRIXPTR         "lX"    /* uintptr_t */
+#endif
+
+typedef struct {
+    intmax_t quot;      /* quotient */
+    intmax_t rem;       /* remainder */
+} imaxdiv_t;
+
+__BEGIN_DECLS
+
+intmax_t _TLIBC_CDECL_ imaxabs(intmax_t);
+imaxdiv_t _TLIBC_CDECL_ imaxdiv(intmax_t, intmax_t);
+intmax_t _TLIBC_CDECL_ strtoimax(const char *, char **, int);
+uintmax_t _TLIBC_CDECL_ strtoumax(const char *, char **, int);
+
+__END_DECLS
+
+#endif /* _INTTYPES_H_ */

--- a/core/build/headers/tlibc/iso646.h
+++ b/core/build/headers/tlibc/iso646.h
@@ -1,0 +1,26 @@
+/*	$OpenBSD: iso646.h,v 1.3 2001/10/11 00:05:21 espie Exp $	*/
+/*	$NetBSD: iso646.h,v 1.1 1995/02/17 09:08:10 jtc Exp $	*/
+
+/* 
+ * Written by J.T. Conklin <jtc@wimsey.com> 02/16/95.
+ * Public domain.
+ */
+
+#ifndef _ISO646_H_
+#define _ISO646_H_
+
+#ifndef __cplusplus
+#define and     &&
+#define and_eq  &=
+#define bitand  &
+#define bitor   |
+#define compl   ~
+#define not     !
+#define not_eq  !=
+#define or      ||
+#define or_eq   |=
+#define xor     ^
+#define xor_eq  ^=
+#endif
+
+#endif  /* !_ISO646_H_ */

--- a/core/build/headers/tlibc/limits.h
+++ b/core/build/headers/tlibc/limits.h
@@ -1,0 +1,41 @@
+/*	$OpenBSD: limits.h,v 1.15 2008/02/10 09:59:54 kettenis Exp $	*/
+/*	$NetBSD: limits.h,v 1.7 1994/10/26 00:56:00 cgd Exp $	*/
+
+/*
+ * Copyright (c) 1988 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)limits.h	5.9 (Berkeley) 4/3/91
+ */
+
+
+#ifndef _LIMITS_H_
+#define _LIMITS_H_
+
+#include <sys/limits.h>
+
+#endif /* !_LIMITS_H_ */

--- a/core/build/headers/tlibc/math.h
+++ b/core/build/headers/tlibc/math.h
@@ -1,0 +1,430 @@
+/*	$OpenBSD: math.h,v 1.27 2010/12/14 11:16:15 martynas Exp $	*/
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice 
+ * is preserved.
+ * ====================================================
+ */
+
+/*
+ * from: @(#)fdlibm.h 5.1 93/09/24
+ */
+
+#ifndef _MATH_H_
+#define _MATH_H_
+
+#include <sys/_types.h>
+#include <sys/cdefs.h>
+#include <sys/limits.h>
+
+#include <float.h>
+
+typedef __float_t       float_t;
+typedef __double_t      double_t;
+
+#define FP_NAN         0x00
+#define FP_INFINITE    0x01
+#define FP_ZERO        0x02
+#define FP_SUBNORMAL   0x03
+#define FP_NORMAL      0x04
+
+#define FP_ILOGB0       (-INT_MAX - 1)
+#define FP_ILOGBNAN     (-INT_MAX - 1)
+
+#define fpclassify(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __fpclassifyf(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __fpclassify(x) \
+    :   __fpclassifyl(x))
+#define isfinite(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __isfinitef(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __isfinite(x) \
+    :   __isfinitel(x))
+#define isnormal(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __isnormalf(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __isnormal(x) \
+    :   __isnormall(x))
+#define signbit(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __signbitf(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __signbit(x) \
+    :   __signbitl(x))
+#define isinf(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __isinff(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __isinf(x) \
+    :   __isinfl(x))
+#define isnan(x) \
+    ((sizeof (x) == sizeof (float)) ? \
+        __isnanf(x) \
+    : (sizeof (x) == sizeof (double)) ? \
+        __isnan(x) \
+    :   __isnanl(x))
+
+#define isgreater(x, y)         (!isunordered((x), (y)) && (x) > (y))
+#define isgreaterequal(x, y)    (!isunordered((x), (y)) && (x) >= (y))
+#define isless(x, y)            (!isunordered((x), (y)) && (x) < (y))
+#define islessequal(x, y)       (!isunordered((x), (y)) && (x) <= (y))
+#define islessgreater(x, y)     (!isunordered((x), (y)) && ((x) > (y) || (y) > (x)))
+#define isunordered(x, y)       (isnan(x) || isnan(y))
+
+__BEGIN_DECLS
+
+extern char __infinity[];
+#define HUGE_VAL    (*(double *)(void *)__infinity)
+#define HUGE_VALF   ((float)HUGE_VAL)
+#define HUGE_VALL   ((long double)HUGE_VAL)
+#define INFINITY    HUGE_VALF
+extern char __nan[];
+#define NAN         (*(float *)(void *)__nan)
+
+/*
+ * ANSI/POSIX
+ */
+double _TLIBC_CDECL_ acos(double);
+double _TLIBC_CDECL_ asin(double);
+double _TLIBC_CDECL_ atan(double);
+double _TLIBC_CDECL_ atan2(double, double);
+double _TLIBC_CDECL_ cos(double);
+double _TLIBC_CDECL_ sin(double);
+double _TLIBC_CDECL_ tan(double);
+
+double _TLIBC_CDECL_ cosh(double);
+double _TLIBC_CDECL_ sinh(double);
+double _TLIBC_CDECL_ tanh(double);
+
+double _TLIBC_CDECL_ exp(double);
+double _TLIBC_CDECL_ frexp(double, int *);
+double _TLIBC_CDECL_ ldexp(double, int);
+double _TLIBC_CDECL_ log(double);
+double _TLIBC_CDECL_ log10(double);
+double _TLIBC_CDECL_ modf(double, double *);
+
+double _TLIBC_CDECL_ pow(double, double);
+double _TLIBC_CDECL_ sqrt(double);
+
+double _TLIBC_CDECL_ ceil(double);
+double _TLIBC_CDECL_ fabs(double);
+double _TLIBC_CDECL_ floor(double);
+double _TLIBC_CDECL_ fmod(double, double);
+
+/*
+ * C99
+ */
+double _TLIBC_CDECL_ acosh(double);
+double _TLIBC_CDECL_ asinh(double);
+double _TLIBC_CDECL_ atanh(double);
+
+double _TLIBC_CDECL_ exp2(double);  
+double _TLIBC_CDECL_ expm1(double);
+int    _TLIBC_CDECL_ ilogb(double);
+double _TLIBC_CDECL_ log1p(double);
+double _TLIBC_CDECL_ log2(double);
+double _TLIBC_CDECL_ logb(double);
+double _TLIBC_CDECL_ scalbn(double, int);
+double _TLIBC_CDECL_ scalbln(double, long int); 
+
+double _TLIBC_CDECL_ cbrt(double);
+double _TLIBC_CDECL_ hypot(double, double);
+
+double _TLIBC_CDECL_ erf(double);
+double _TLIBC_CDECL_ erfc(double);
+double _TLIBC_CDECL_ lgamma(double);
+double _TLIBC_CDECL_ tgamma(double);
+
+double _TLIBC_CDECL_ nearbyint(double);
+double _TLIBC_CDECL_ rint(double);
+long int _TLIBC_CDECL_ lrint(double); 
+long long int _TLIBC_CDECL_ llrint(double); 
+double _TLIBC_CDECL_ round(double);  
+long int _TLIBC_CDECL_ lround(double); 
+long long int _TLIBC_CDECL_ llround(double);
+double _TLIBC_CDECL_ trunc(double);
+
+double _TLIBC_CDECL_ remainder(double, double);
+double _TLIBC_CDECL_ remquo(double, double, int *); 
+
+double _TLIBC_CDECL_ copysign(double, double);
+double _TLIBC_CDECL_ nan(const char *);
+double _TLIBC_CDECL_ nextafter(double, double);
+
+double _TLIBC_CDECL_ fdim(double, double); 
+double _TLIBC_CDECL_ fmax(double, double); 
+double _TLIBC_CDECL_ fmin(double, double); 
+
+double _TLIBC_CDECL_ fma(double, double, double);
+
+/*
+ * Float versions of C99 functions
+ */
+
+float _TLIBC_CDECL_ acosf(float);
+float _TLIBC_CDECL_ asinf(float);
+float _TLIBC_CDECL_ atanf(float);
+float _TLIBC_CDECL_ atan2f(float, float);
+float _TLIBC_CDECL_ cosf(float);
+float _TLIBC_CDECL_ sinf(float);
+float _TLIBC_CDECL_ tanf(float);
+
+float _TLIBC_CDECL_ acoshf(float);
+float _TLIBC_CDECL_ asinhf(float);
+float _TLIBC_CDECL_ atanhf(float);
+float _TLIBC_CDECL_ coshf(float);
+float _TLIBC_CDECL_ sinhf(float);
+float _TLIBC_CDECL_ tanhf(float);
+
+float _TLIBC_CDECL_ expf(float);
+float _TLIBC_CDECL_ exp2f(float); 
+float _TLIBC_CDECL_ expm1f(float); 
+float _TLIBC_CDECL_ frexpf(float, int *);
+int   _TLIBC_CDECL_ ilogbf(float);
+float _TLIBC_CDECL_ ldexpf(float, int);
+float _TLIBC_CDECL_ logf(float);
+float _TLIBC_CDECL_ log10f(float);
+float _TLIBC_CDECL_ log1pf(float);
+float _TLIBC_CDECL_ log2f(float);
+float _TLIBC_CDECL_ logbf(float);
+float _TLIBC_CDECL_ modff(float, float *);
+float _TLIBC_CDECL_ scalbnf(float, int);
+float _TLIBC_CDECL_ scalblnf(float, long int);
+
+float _TLIBC_CDECL_ cbrtf(float);
+float _TLIBC_CDECL_ fabsf(float);
+float _TLIBC_CDECL_ hypotf(float, float);
+float _TLIBC_CDECL_ powf(float, float);
+float _TLIBC_CDECL_ sqrtf(float);
+
+float _TLIBC_CDECL_ erff(float);
+float _TLIBC_CDECL_ erfcf(float);
+float _TLIBC_CDECL_ lgammaf(float);
+float _TLIBC_CDECL_ tgammaf(float);
+
+float _TLIBC_CDECL_ ceilf(float);
+float _TLIBC_CDECL_ floorf(float);
+float _TLIBC_CDECL_ nearbyintf(float);
+
+float _TLIBC_CDECL_ rintf(float);
+long int _TLIBC_CDECL_ lrintf(float); 
+long long int _TLIBC_CDECL_ llrintf(float); 
+float _TLIBC_CDECL_ roundf(float); 
+long int _TLIBC_CDECL_ lroundf(float);
+long long int _TLIBC_CDECL_ llroundf(float);
+float _TLIBC_CDECL_ truncf(float);
+
+float _TLIBC_CDECL_ fmodf(float, float);
+float _TLIBC_CDECL_ remainderf(float, float);
+float _TLIBC_CDECL_ remquof(float, float, int *);
+
+float _TLIBC_CDECL_ copysignf(float, float);
+float _TLIBC_CDECL_ nanf(const char *);
+float _TLIBC_CDECL_ nextafterf(float, float);
+
+float _TLIBC_CDECL_ fdimf(float, float);
+float _TLIBC_CDECL_ fmaxf(float, float);
+float _TLIBC_CDECL_ fminf(float, float);
+
+float _TLIBC_CDECL_ fmaf(float, float, float);
+
+/*
+ * Long double versions of C99 functions
+ */
+
+/* Macros defining long double functions to be their double counterparts
+ * (long double is synonymous with double in this implementation).
+ */
+
+long double _TLIBC_CDECL_ acosl(long double);
+long double _TLIBC_CDECL_ asinl(long double);
+long double _TLIBC_CDECL_ atanl(long double);
+long double _TLIBC_CDECL_ atan2l(long double, long double);
+long double _TLIBC_CDECL_ cosl(long double);
+long double _TLIBC_CDECL_ sinl(long double);
+long double _TLIBC_CDECL_ tanl(long double);
+
+long double _TLIBC_CDECL_ acoshl(long double);
+long double _TLIBC_CDECL_ asinhl(long double);
+long double _TLIBC_CDECL_ atanhl(long double);
+long double _TLIBC_CDECL_ coshl(long double);
+long double _TLIBC_CDECL_ sinhl(long double);
+long double _TLIBC_CDECL_ tanhl(long double);
+
+long double _TLIBC_CDECL_ expl(long double);
+long double _TLIBC_CDECL_ exp2l(long double);
+long double _TLIBC_CDECL_ expm1l(long double);
+long double _TLIBC_CDECL_ frexpl(long double, int *);
+int         _TLIBC_CDECL_ ilogbl(long double);
+long double _TLIBC_CDECL_ ldexpl(long double, int);
+long double _TLIBC_CDECL_ logl(long double);
+long double _TLIBC_CDECL_ log10l(long double);
+long double _TLIBC_CDECL_ log1pl(long double);
+long double _TLIBC_CDECL_ log2l(long double);
+long double _TLIBC_CDECL_ logbl(long double);
+long double _TLIBC_CDECL_ modfl(long double, long double *);
+long double _TLIBC_CDECL_ scalbnl(long double, int);
+long double _TLIBC_CDECL_ scalblnl(long double, long int);
+
+long double _TLIBC_CDECL_ cbrtl(long double);
+long double _TLIBC_CDECL_ fabsl(long double);
+long double _TLIBC_CDECL_ hypotl(long double, long double);
+long double _TLIBC_CDECL_ powl(long double, long double);
+long double _TLIBC_CDECL_ sqrtl(long double);
+
+long double _TLIBC_CDECL_ erfl(long double);
+long double _TLIBC_CDECL_ erfcl(long double);
+long double _TLIBC_CDECL_ lgammal(long double);
+long double _TLIBC_CDECL_ tgammal(long double);
+
+long double _TLIBC_CDECL_ ceill(long double);
+long double _TLIBC_CDECL_ floorl(long double);
+long double _TLIBC_CDECL_ nearbyintl(long double);
+long double _TLIBC_CDECL_ rintl(long double);
+long int    _TLIBC_CDECL_ lrintl(long double);
+long long int _TLIBC_CDECL_ llrintl(long double);
+long double _TLIBC_CDECL_ roundl(long double);
+long int    _TLIBC_CDECL_ lroundl(long double);
+long long int _TLIBC_CDECL_ llroundl(long double);
+long double _TLIBC_CDECL_ truncl(long double);
+
+long double _TLIBC_CDECL_ fmodl(long double, long double);
+long double _TLIBC_CDECL_ remainderl(long double, long double);
+long double _TLIBC_CDECL_ remquol(long double, long double, int *);
+
+long double _TLIBC_CDECL_ copysignl(long double, long double);
+long double _TLIBC_CDECL_ nanl(const char *);
+long double _TLIBC_CDECL_ nextafterl(long double, long double);
+
+long double _TLIBC_CDECL_ fdiml(long double, long double);
+long double _TLIBC_CDECL_ fmaxl(long double, long double);
+long double _TLIBC_CDECL_ fminl(long double, long double);
+long double _TLIBC_CDECL_ fmal(long double, long double, long double);
+
+/* nexttoward():
+*      The implementation in Intel math library is incompatible with MSVC.
+*      Because sizeof(long double) is 8bytes with MSVC, 
+*      but the expected long double size is 10bytes. 
+*      And by default, MSVC doesn't provide nexttoward(). 
+*      So we only provide Linux version here.
+*/
+double _TLIBC_CDECL_ nexttoward(double, long double);
+float  _TLIBC_CDECL_ nexttowardf(float, long double);
+
+long double _TLIBC_CDECL_ nexttowardl(long double, long double);
+
+/*
+ * Library implementation
+ */
+int _TLIBC_CDECL_ __fpclassify(double);
+int _TLIBC_CDECL_ __fpclassifyf(float);
+int _TLIBC_CDECL_ __isfinite(double);
+int _TLIBC_CDECL_ __isfinitef(float);
+int _TLIBC_CDECL_ __isinf(double);
+int _TLIBC_CDECL_ __isinff(float);
+int _TLIBC_CDECL_ __isnan(double);
+int _TLIBC_CDECL_ __isnanf(float);
+int _TLIBC_CDECL_ __isnormal(double);
+int _TLIBC_CDECL_ __isnormalf(float);
+int _TLIBC_CDECL_ __signbit(double);
+int _TLIBC_CDECL_ __signbitf(float);
+
+int _TLIBC_CDECL_ __fpclassifyl(long double);
+int _TLIBC_CDECL_ __isfinitel(long double);
+int _TLIBC_CDECL_ __isinfl(long double);
+int _TLIBC_CDECL_ __isnanl(long double);
+int _TLIBC_CDECL_ __isnormall(long double);
+int _TLIBC_CDECL_ __signbitl(long double);
+
+/* 
+ * Non-C99 functions.
+ */
+double _TLIBC_CDECL_ drem(double, double);
+double _TLIBC_CDECL_ exp10(double);
+double _TLIBC_CDECL_ gamma(double);
+double _TLIBC_CDECL_ gamma_r(double, int *);
+double _TLIBC_CDECL_ j0(double);
+double _TLIBC_CDECL_ j1(double);
+double _TLIBC_CDECL_ jn(int, double);
+double _TLIBC_CDECL_ lgamma_r(double, int *);
+double _TLIBC_CDECL_ pow10(double);
+double _TLIBC_CDECL_ scalb(double, double);
+/* C99 Macro signbit.*/
+double _TLIBC_CDECL_ significand(double);
+void   _TLIBC_CDECL_ sincos(double, double *, double *);
+double _TLIBC_CDECL_ y0(double);
+double _TLIBC_CDECL_ y1(double);
+double _TLIBC_CDECL_ yn(int, double);
+/* C99 Macro isinf.*/
+/* C99 Macro isnan.*/
+int    _TLIBC_CDECL_ finite(double);
+
+float _TLIBC_CDECL_ dremf(float, float);
+float _TLIBC_CDECL_ exp10f(float);
+float _TLIBC_CDECL_ gammaf(float);
+float _TLIBC_CDECL_ gammaf_r(float, int *);
+float _TLIBC_CDECL_ j0f(float);
+float _TLIBC_CDECL_ j1f(float);
+float _TLIBC_CDECL_ jnf(int, float);
+float _TLIBC_CDECL_ lgammaf_r(float, int *);
+float _TLIBC_CDECL_ pow10f(float);
+float _TLIBC_CDECL_ scalbf(float, float);
+int   _TLIBC_CDECL_ signbitf(float);
+float _TLIBC_CDECL_ significandf(float);
+void  _TLIBC_CDECL_ sincosf(float, float *, float *);
+float _TLIBC_CDECL_ y0f(float);
+float _TLIBC_CDECL_ y1f(float);
+float _TLIBC_CDECL_ ynf(int, float);
+int   _TLIBC_CDECL_ finitef(float);
+int   _TLIBC_CDECL_ isinff(float);
+int   _TLIBC_CDECL_ isnanf(float);
+
+long double _TLIBC_CDECL_ dreml(long double, long double);
+long double _TLIBC_CDECL_ exp10l(long double);
+long double _TLIBC_CDECL_ gammal(long double);
+long double _TLIBC_CDECL_ gammal_r(long double, int *);
+long double _TLIBC_CDECL_ j0l(long double);
+long double _TLIBC_CDECL_ j1l(long double);
+long double _TLIBC_CDECL_ jnl(int, long double);
+long double _TLIBC_CDECL_ lgammal_r(long double, int *);
+long double _TLIBC_CDECL_ pow10l(long double);
+long double _TLIBC_CDECL_ scalbl(long double, long double);
+int         _TLIBC_CDECL_ signbitl(long double);
+long double _TLIBC_CDECL_ significandl(long double);
+void        _TLIBC_CDECL_ sincosl(long double, long double *, long double *);
+long double _TLIBC_CDECL_ y1l(long double);
+long double _TLIBC_CDECL_ y0l(long double);
+long double _TLIBC_CDECL_ ynl(int, long double);
+int         _TLIBC_CDECL_ finitel(long double);
+int         _TLIBC_CDECL_ isinfl(long double);
+int         _TLIBC_CDECL_ isnanl(long double);
+
+/* 
+ * TODO: From Intel Decimal Floating-Point Math Library
+ * signbitd32/signbitd64/signbitd128, finited32/finited64/finited128
+ * isinfd32/isinfd64/isinfd128, isnand32/isnand64/isnand128
+ */
+#if defined(__cplusplus) 
+/* Clang does not support decimal floating point types.
+ *
+ * c.f.:
+ * http://clang.llvm.org/docs/UsersManual.html#gcc-extensions-not-implemented-yet
+ */
+#if !defined(__clang__)
+typedef float _Decimal32 __attribute__((mode(SD)));
+typedef float _Decimal64 __attribute__((mode(DD)));
+typedef float _Decimal128 __attribute__((mode(TD)));
+#endif
+#endif
+
+__END_DECLS
+
+#endif /* !_MATH_H_ */

--- a/core/build/headers/tlibc/mbusafecrt.h
+++ b/core/build/headers/tlibc/mbusafecrt.h
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+/***
+*   mbusafecrt.h - public declarations for SafeCRT lib
+*
+
+*
+*   Purpose:
+*       This file contains the public declarations SafeCRT
+*       functions ported to MacOS. These are the safe versions of
+*       functions standard functions banned by SWI
+*
+
+****/
+
+/* shields! */
+
+#ifndef MBUSAFECRT_H
+#define MBUSAFECRT_H
+#include <string.h>
+#include <stdarg.h>
+#include <wchar.h>
+typedef wchar_t WCHAR;
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+extern errno_t strcat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc );
+extern errno_t wcscat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc );
+
+extern errno_t strncat_s( char* ioDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
+extern errno_t wcsncat_s( WCHAR* ioDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
+
+extern errno_t strcpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc );
+extern errno_t wcscpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc );
+
+extern errno_t strncpy_s( char* outDest, size_t inDestBufferSize, const char* inSrc, size_t inCount );
+extern errno_t wcsncpy_s( WCHAR* outDest, size_t inDestBufferSize, const WCHAR* inSrc, size_t inCount );
+
+extern char* strtok_s( char* inString, const char* inControl, char** ioContext );
+extern WCHAR* wcstok_s( WCHAR* inString, const WCHAR* inControl, WCHAR** ioContext );
+
+extern size_t wcsnlen( const WCHAR* inString, size_t inMaxSize );
+
+extern errno_t _itoa_s( int inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern errno_t _itow_s( int inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+
+extern errno_t _ltoa_s( long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern errno_t _ltow_s( long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+
+extern errno_t _ultoa_s( unsigned long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern errno_t _ultow_s( unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+
+extern errno_t _i64toa_s( long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern errno_t _i64tow_s( long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+
+extern errno_t _ui64toa_s( unsigned long long inValue, char* outBuffer, size_t inDestBufferSize, int inRadix );
+extern errno_t _ui64tow_s( unsigned long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
+
+extern int sprintf_s( char *string, size_t sizeInBytes, const char *format, ... );
+extern int swprintf_s( WCHAR *string, size_t sizeInWords, const WCHAR *format, ... );
+
+extern int _snprintf_s( char *string, size_t sizeInBytes, size_t count, const char *format, ... );
+extern int _snwprintf_s( WCHAR *string, size_t sizeInWords, size_t count, const WCHAR *format, ... );
+
+extern int _vsprintf_s( char* string, size_t sizeInBytes, const char* format, va_list arglist );
+extern int _vsnprintf_s( char* string, size_t sizeInBytes, size_t count, const char* format, va_list arglist );
+
+extern int _vswprintf_s( WCHAR* string, size_t sizeInWords, const WCHAR* format, va_list arglist );
+extern int _vsnwprintf_s( WCHAR* string, size_t sizeInWords, size_t count, const WCHAR* format, va_list arglist );
+
+extern errno_t memcpy_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern errno_t memcpy_verw_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern errno_t memmove_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+extern errno_t memmove_verw_s( void * dst, size_t sizeInBytes, const void * src, size_t count );
+
+#ifdef __cplusplus
+    }
+#endif
+
+#endif	/* MBUSAFECRT_H */

--- a/core/build/headers/tlibc/pthread.h
+++ b/core/build/headers/tlibc/pthread.h
@@ -1,0 +1,123 @@
+
+/**
+ *
+ * Copyright(c) 2011-2019 Intel Corporation All Rights Reserved.
+ *
+ * The source code contained or described herein and all documents related to
+ * the source code ("Material") are owned by Intel Corporation or its suppliers
+ * or licensors. Title to the Material remains with Intel Corporation or its
+ * suppliers and licensors. The Material contains trade secrets and proprietary
+ * and confidential information of Intel or its suppliers and licensors. The
+ * Material is protected by worldwide copyright and trade secret laws and treaty
+ * provisions. No part of the Material may be used, copied, reproduced, modified,
+ * published, uploaded, posted, transmitted, distributed, or disclosed in any
+ * way without Intel's prior express written permission.
+ *
+ * No license under any patent, copyright, trade secret or other intellectual
+ * property right is granted to or conferred upon you by disclosure or delivery
+ * of the Materials, either expressly, by implication, inducement, estoppel or
+ * otherwise. Any license under such intellectual property rights must be
+ * express and approved by Intel(R) in writing.
+ *
+ */
+
+#ifndef _PTHREAD_H_
+#define _PTHREAD_H_
+
+#include <sgx_defs.h>
+#include <sgx_thread.h>
+
+/*
+ * Flags for once initialization.
+ */
+#define PTHREAD_NEEDS_INIT  0
+#define PTHREAD_DONE_INIT   1
+
+/*
+ * Static once initialization values. 
+ */
+#define PTHREAD_ONCE_INIT   { PTHREAD_NEEDS_INIT, PTHREAD_MUTEX_INITIALIZER }
+
+/*
+ * Static initialization values. 
+ */
+#define PTHREAD_MUTEX_INITIALIZER   SGX_THREAD_MUTEX_INITIALIZER
+#define PTHREAD_COND_INITIALIZER    SGX_THREAD_COND_INITIALIZER
+#define PTHREAD_RWLOCK_INITIALIZER  SGX_THREAD_LOCK_INITIALIZER
+
+/*
+ * Primitive system data type definitions required by P1003.1c.
+ *
+ * Note that P1003.1c specifies that there are no defined comparison
+ * or assignment operators for the types pthread_attr_t, pthread_cond_t,
+ * pthread_condattr_t, pthread_mutex_t, pthread_mutexattr_t.
+ */
+typedef struct  _pthread                    *pthread_t;
+typedef struct  _pthread_attr               *pthread_attr_t;
+typedef struct  _sgx_thread_mutex_t         pthread_mutex_t;
+typedef struct  _sgx_thread_mutex_attr_t    pthread_mutexattr_t;
+typedef struct  _sgx_thread_cond_t          pthread_cond_t;
+typedef struct  _sgx_thread_cond_attr_t     pthread_condattr_t;
+typedef         int                         pthread_key_t;
+typedef struct  _sgx_thread_rwlock_t        pthread_rwlock_t;
+typedef struct  _sgx_thread_rwlockattr_t    pthread_rwlockattr_t;
+
+/*
+ * Once definitions.
+ */
+typedef struct _pthread_once_t {
+	int		state;
+	pthread_mutex_t	mutex;
+}pthread_once_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Create & exit */
+int SGXAPI pthread_create(pthread_t *, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *);
+void SGXAPI pthread_exit(void *);
+int SGXAPI pthread_join(pthread_t, void **);
+
+/* Mutex */
+int SGXAPI pthread_mutex_init(pthread_mutex_t *, const pthread_mutexattr_t *);
+int SGXAPI pthread_mutex_destroy(pthread_mutex_t *);
+
+int SGXAPI pthread_mutex_lock(pthread_mutex_t *);
+int SGXAPI pthread_mutex_trylock(pthread_mutex_t *);
+int SGXAPI pthread_mutex_unlock(pthread_mutex_t *);
+
+/* Condition Variable */
+int SGXAPI pthread_cond_init(pthread_cond_t *, const pthread_condattr_t *);
+int SGXAPI pthread_cond_destroy(pthread_cond_t *);
+
+int SGXAPI pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *);
+int SGXAPI pthread_cond_signal(pthread_cond_t *);
+int SGXAPI pthread_cond_broadcast(pthread_cond_t *);
+
+/* RW Locks */
+int SGXAPI pthread_rwlock_init(pthread_rwlock_t *, const pthread_rwlockattr_t *);
+int SGXAPI pthread_rwlock_destroy(pthread_rwlock_t *);
+int SGXAPI pthread_rwlock_rdlock(pthread_rwlock_t *);
+int SGXAPI pthread_rwlock_tryrdlock(pthread_rwlock_t *);
+int SGXAPI pthread_rwlock_wrlock(pthread_rwlock_t *);
+int SGXAPI pthread_rwlock_trywrlock(pthread_rwlock_t *);
+int SGXAPI pthread_rwlock_unlock(pthread_rwlock_t *);
+
+/* tls */
+int SGXAPI pthread_key_create(pthread_key_t *, void (*destructor)(void*));
+int SGXAPI pthread_key_delete(pthread_key_t);
+void * SGXAPI pthread_getspecific(pthread_key_t);
+int SGXAPI pthread_setspecific(pthread_key_t, const void *);
+
+pthread_t SGXAPI pthread_self(void);
+int SGXAPI pthread_equal(pthread_t, pthread_t);
+int SGXAPI pthread_once(pthread_once_t*, void (*init_routine)(void));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  //_PTHREAD_H_
+

--- a/core/build/headers/tlibc/setjmp.h
+++ b/core/build/headers/tlibc/setjmp.h
@@ -1,0 +1,65 @@
+/*	$NetBSD: setjmp.h,v 1.26 2011/11/05 09:27:06 joerg Exp $	*/
+
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)setjmp.h	8.2 (Berkeley) 1/21/94
+ */
+
+#ifndef _SETJMP_H_
+#define _SETJMP_H_
+
+#ifndef _JB_ATTRIBUTES
+#define _JB_ATTRIBUTES /**/
+#else
+#endif
+#ifndef _BSD_JBSLOT_T_
+#define _BSD_JBSLOT_T_ long
+#endif
+
+#define _JBLEN 8 
+
+typedef _BSD_JBSLOT_T_ jmp_buf[_JBLEN] _JB_ATTRIBUTES;
+
+#include <sys/cdefs.h>
+#define __returns_twice __attribute__((__returns_twice__))
+#define __dead 
+
+
+__BEGIN_DECLS
+int setjmp(jmp_buf) __returns_twice;
+void longjmp(jmp_buf, int) __dead;
+__END_DECLS
+
+#endif /* !_SETJMP_H_ */
+

--- a/core/build/headers/tlibc/stdarg.h
+++ b/core/build/headers/tlibc/stdarg.h
@@ -1,0 +1,48 @@
+/*	$OpenBSD: stdarg.h,v 1.14 2010/12/30 05:01:36 tedu Exp $	*/
+/*	$NetBSD: stdarg.h,v 1.12 1995/12/25 23:15:31 mycroft Exp $	*/
+
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)stdarg.h	8.1 (Berkeley) 6/10/93
+ */
+
+#ifndef _STDARG_H_
+#define _STDARG_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+typedef __va_list   va_list;
+
+#define va_start(ap, last)  __builtin_va_start((ap), last)
+#define va_end              __builtin_va_end
+#define va_arg              __builtin_va_arg
+#define va_copy(dst, src)   __builtin_va_copy((dst),(src))
+
+#endif /* !_STDARG_H_ */

--- a/core/build/headers/tlibc/stdbool.h
+++ b/core/build/headers/tlibc/stdbool.h
@@ -1,0 +1,44 @@
+/* $OpenBSD: stdbool.h,v 1.5 2010/07/24 22:17:03 guenther Exp $ */
+
+/*
+ * Written by Marc Espie, September 25, 1999
+ * Public domain.
+ */
+
+#ifndef _STDBOOL_H_
+#define _STDBOOL_H_
+
+#ifndef __cplusplus
+
+#ifndef __GNUC__
+/* Support for _C99: type _Bool is already built-in. */
+/* `_Bool' type must promote to `int' or `unsigned int'. */
+typedef enum {
+    false = 0,
+    true = 1
+} _Bool;
+
+/* And those constants must also be available as macros. */
+# define false   false
+# define true    true
+#else  /* __GNUC__ */
+# define false   0
+# define true    1
+#endif
+
+/* User visible type `bool' is provided as a macro which may be redefined */
+#define bool _Bool
+
+#else /* __cplusplus */
+
+# define _Bool   bool
+# define bool    bool
+# define false   false
+# define true    true
+
+#endif
+
+/* Inform that everything is fine */
+#define __bool_true_false_are_defined 1
+
+#endif /* _STDBOOL_H_ */

--- a/core/build/headers/tlibc/stddef.h
+++ b/core/build/headers/tlibc/stddef.h
@@ -1,0 +1,70 @@
+/*	$OpenBSD: stddef.h,v 1.10 2009/09/22 21:40:02 jsg Exp $	*/
+/*	$NetBSD: stddef.h,v 1.4 1994/10/26 00:56:26 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)stddef.h	5.5 (Berkeley) 4/3/91
+ */
+
+#ifndef _STDDEF_H_
+#define _STDDEF_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#ifndef _PTRDIFF_T_DEFINED_
+#define _PTRDIFF_T_DEFINED_
+typedef __ptrdiff_t ptrdiff_t;
+#endif
+
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#endif
+
+#if !defined(_WCHAR_T_DEFINED_) && !defined(__cplusplus)
+#define _WCHAR_T_DEFINED_
+#ifndef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ int
+#endif
+typedef __WCHAR_TYPE__ wchar_t;
+#endif
+
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL        0
+#else
+#define NULL        ((void *)0)
+#endif
+#endif
+
+#define offsetof(type, member)   __builtin_offsetof (type, member)
+
+#endif /* _STDDEF_H_ */
+

--- a/core/build/headers/tlibc/stdint.h
+++ b/core/build/headers/tlibc/stdint.h
@@ -1,0 +1,24 @@
+/*	$OpenBSD: stdint.h,v 1.4 2006/12/10 22:17:55 deraadt Exp $	*/
+
+/*
+ * Copyright (c) 1997, 2005 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef	_STDINT_H_
+#define _STDINT_H_
+
+#include <sys/stdint.h>
+
+#endif /* _STDINT_H_ */

--- a/core/build/headers/tlibc/stdio.h
+++ b/core/build/headers/tlibc/stdio.h
@@ -1,0 +1,95 @@
+/*	$OpenBSD: stdio.h,v 1.38 2009/11/09 00:18:27 kurt Exp $	*/
+/*	$NetBSD: stdio.h,v 1.18 1996/04/25 18:29:21 jtc Exp $	*/
+
+/*-
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)stdio.h	5.17 (Berkeley) 6/3/91
+ */
+
+#ifndef _STDIO_H_
+#define _STDIO_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#include <stdarg.h>
+
+#ifndef _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#define _SIZE_T_DEFINED_
+#endif
+
+#ifndef NULL
+# ifdef __cplusplus
+#  define NULL      0
+# else
+#  define NULL      ((void *)0)
+# endif
+#endif
+
+# define BUFSIZ  8192
+
+#define EOF     (-1)
+
+__BEGIN_DECLS
+
+int _TLIBC_CDECL_ snprintf(char *, size_t, const char *, ...) _GCC_PRINTF_FORMAT_(3, 4);
+int _TLIBC_CDECL_ vsnprintf(char *, size_t, const char *, __va_list) _GCC_PRINTF_FORMAT_(3, 0);
+
+/*
+ * Deprecated definitions.
+ */
+#if 0 /* No FILE */
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, fprintf, FILE *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, putc, int, FILE *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, fputc, int, FILE *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, fputs, const char *, FILE *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, fscanf, FILE *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(size_t _TLIBC_CDECL_, fwrite, const void *, size_t, size_t, FILE *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, printf, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, putchar, int);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, puts, const char *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, scanf, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, sprintf, char *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, sscanf, const char *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vfprintf, FILE *, const char *, __va_list);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vfscanf, FILE *, const char *, __va_list);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vprintf, const char *, __va_list);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vscanf, const char *, __va_list);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vsprintf, char *, const char *, __va_list);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, vsscanf, const char *, const char *, __va_list);
+#endif
+
+__END_DECLS
+
+
+#endif /* !_STDIO_H_ */

--- a/core/build/headers/tlibc/stdlib.h
+++ b/core/build/headers/tlibc/stdlib.h
@@ -1,0 +1,152 @@
+/*	$OpenBSD: stdlib.h,v 1.47 2010/05/18 22:24:55 tedu Exp $	*/
+/*	$NetBSD: stdlib.h,v 1.25 1995/12/27 21:19:08 jtc Exp $	*/
+
+/*-
+* Copyright (c) 1990 The Regents of the University of California.
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+* 3. Neither the name of the University nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+* SUCH DAMAGE.
+*
+*	@(#)stdlib.h	5.13 (Berkeley) 6/4/91
+*/
+
+#ifndef _STDLIB_H_
+#define _STDLIB_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#endif
+
+#if !defined(_WCHAR_T_DEFINED_) && !defined(__cplusplus)
+#define _WCHAR_T_DEFINED_
+#ifndef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ int
+#endif
+typedef __WCHAR_TYPE__ wchar_t;
+#endif
+
+#ifndef _DIV_T_DEFINED
+typedef struct {
+    int quot;       /* quotient */
+    int rem;        /* remainder */
+} div_t;
+
+typedef struct {
+    long quot;      /* quotient */
+    long rem;       /* remainder */
+} ldiv_t;
+
+typedef struct {
+    long long quot; /* quotient */
+    long long rem;  /* remainder */
+} lldiv_t;
+#define _DIV_T_DEFINED
+#endif
+
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL    0
+#else
+#define NULL    ((void *)0)
+#endif
+#endif
+
+#define EXIT_FAILURE    1
+#define EXIT_SUCCESS    0
+
+#define RAND_MAX        0x7fffffff
+#define MB_CUR_MAX      1
+
+__BEGIN_DECLS
+
+_TLIBC_NORETURN_ void _TLIBC_CDECL_ abort(void);
+int     _TLIBC_CDECL_ atexit(void (*)(void));
+int     _TLIBC_CDECL_ abs(int);
+double  _TLIBC_CDECL_ atof(const char *);
+int     _TLIBC_CDECL_ atoi(const char *);
+long    _TLIBC_CDECL_ atol(const char *);
+void *  _TLIBC_CDECL_ bsearch(const void *, const void *, size_t, size_t, int (*)(const void *, const void *));
+void *  _TLIBC_CDECL_ calloc(size_t, size_t);
+div_t   _TLIBC_CDECL_ div(int, int);
+void    _TLIBC_CDECL_ free(void *);
+long    _TLIBC_CDECL_ labs(long);
+ldiv_t  _TLIBC_CDECL_ ldiv(long, long);
+void *  _TLIBC_CDECL_ malloc(size_t);
+void *  _TLIBC_CDECL_ memalign(size_t, size_t);
+void    _TLIBC_CDECL_ qsort(void *, size_t, size_t, int (*)(const void *, const void *));
+void *  _TLIBC_CDECL_ realloc(void *, size_t);
+double  _TLIBC_CDECL_ strtod(const char *, char **);
+long    _TLIBC_CDECL_ strtol(const char *, char **, int);
+float   _TLIBC_CDECL_ strtof(const char *, char **);
+
+long long
+        _TLIBC_CDECL_ atoll(const char *);
+long long
+        _TLIBC_CDECL_ llabs(long long);
+lldiv_t
+        _TLIBC_CDECL_ lldiv(long long, long long);
+long long
+        _TLIBC_CDECL_ strtoll(const char *, char **, int);
+unsigned long
+        _TLIBC_CDECL_ strtoul(const char *, char **, int);
+long double
+        _TLIBC_CDECL_ strtold(const char *, char **);
+unsigned long long
+        _TLIBC_CDECL_ strtoull(const char *, char **, int);
+
+int     _TLIBC_CDECL_ mblen(const char *, size_t);
+size_t  _TLIBC_CDECL_ mbstowcs(wchar_t *, const char *, size_t);
+int     _TLIBC_CDECL_ wctomb(char *, wchar_t);
+int     _TLIBC_CDECL_ mbtowc(wchar_t *, const char *, size_t);
+size_t  _TLIBC_CDECL_ wcstombs(char *, const wchar_t *, size_t);
+
+
+/*
+ * Deprecated C99.
+ */
+_TLIBC_DEPRECATED_FUNCTION_(int     _TLIBC_CDECL_, rand, void);
+_TLIBC_DEPRECATED_FUNCTION_(void    _TLIBC_CDECL_, srand, unsigned);
+_TLIBC_DEPRECATED_FUNCTION_(void    _TLIBC_CDECL_, exit, int);
+_TLIBC_DEPRECATED_FUNCTION_(void    _TLIBC_CDECL_, _Exit, int);
+_TLIBC_DEPRECATED_FUNCTION_(char *  _TLIBC_CDECL_, getenv, const char *);
+_TLIBC_DEPRECATED_FUNCTION_(int     _TLIBC_CDECL_, system, const char *);
+
+/*
+ * Non-C99 Functions.
+ */
+void *  _TLIBC_CDECL_ alloca(size_t);
+
+/*
+ * Deprecated Non-C99.
+ */
+//_TLIBC_DEPRECATED_FUNCTION_(void _TLIBC_CDECL_, _exit, int);
+
+__END_DECLS
+
+#endif /* !_STDLIB_H_ */

--- a/core/build/headers/tlibc/string.h
+++ b/core/build/headers/tlibc/string.h
@@ -1,0 +1,129 @@
+/*	$OpenBSD: string.h,v 1.20 2010/09/24 13:33:00 matthew Exp $	*/
+/*	$NetBSD: string.h,v 1.6 1994/10/26 00:56:30 cgd Exp $	*/
+
+/*-
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)string.h	5.10 (Berkeley) 3/9/91
+ */
+
+#ifndef _STRING_H_
+#define _STRING_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#ifndef _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#define _SIZE_T_DEFINED_
+#endif
+
+#ifndef _ERRNO_T_DEFINED
+#define _ERRNO_T_DEFINED
+typedef int errno_t;
+#endif
+
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL    0
+#else
+#define NULL    ((void *)0)
+#endif
+#endif
+
+__BEGIN_DECLS
+
+void * _TLIBC_CDECL_ memchr(const void *, int, size_t);
+int    _TLIBC_CDECL_ memcmp(const void *, const void *, size_t);
+void * _TLIBC_CDECL_ memcpy(void *, const void *, size_t);
+void * _TLIBC_CDECL_ memcpy_verw(void *, const void *, size_t);
+void * _TLIBC_CDECL_ memmove(void *, const void *, size_t);
+void * _TLIBC_CDECL_ memmove_verw(void *, const void *, size_t);
+void * _TLIBC_CDECL_ memset(void *, int, size_t);
+void * _TLIBC_CDECL_ memset_verw(void *, int, size_t);
+char * _TLIBC_CDECL_ strchr(const char *, int);
+int    _TLIBC_CDECL_ strcmp(const char *, const char *);
+int    _TLIBC_CDECL_ strcoll(const char *, const char *);
+size_t _TLIBC_CDECL_ strcspn(const char *, const char *);
+char * _TLIBC_CDECL_ strerror(int);
+size_t _TLIBC_CDECL_ strlen(const char *);
+char * _TLIBC_CDECL_ strncat(char *, const char *, size_t);
+int    _TLIBC_CDECL_ strncmp(const char *, const char *, size_t);
+char * _TLIBC_CDECL_ strncpy(char *, const char *, size_t);
+char * _TLIBC_CDECL_ strpbrk(const char *, const char *);
+char * _TLIBC_CDECL_ strrchr(const char *, int);
+size_t _TLIBC_CDECL_ strspn(const char *, const char *);
+char * _TLIBC_CDECL_ strstr(const char *, const char *);
+char * _TLIBC_CDECL_ strtok(char *, const char *);
+size_t _TLIBC_CDECL_ strxfrm(char *, const char *, size_t);
+size_t _TLIBC_CDECL_ strlcpy(char *, const char *, size_t);
+errno_t _TLIBC_CDECL_ memset_s(void *s, size_t smax, int c, size_t n);
+errno_t _TLIBC_CDECL_ memset_verw_s(void *s, size_t smax, int c, size_t n);
+
+/*
+ * Deprecated C99.
+ */
+_TLIBC_DEPRECATED_FUNCTION_(char * _TLIBC_CDECL_, strcat, char *, const char *);
+_TLIBC_DEPRECATED_FUNCTION_(char * _TLIBC_CDECL_, strcpy, char *, const char *);
+
+/* 
+ * Common used non-C99 functions.
+ */
+char * _TLIBC_CDECL_ strndup(const char *, size_t);
+size_t _TLIBC_CDECL_ strnlen(const char *, size_t);
+int    _TLIBC_CDECL_ consttime_memequal(const void *b1, const void *b2, size_t len);
+
+/*
+ * Non-C99
+ */
+int    _TLIBC_CDECL_ bcmp(const void *, const void *, size_t);
+void   _TLIBC_CDECL_ bcopy(const void *, void *, size_t);
+void   _TLIBC_CDECL_ bzero(void *, size_t);
+char * _TLIBC_CDECL_ index(const char *, int);
+void * _TLIBC_CDECL_ mempcpy(void *, const void *, size_t);
+char * _TLIBC_CDECL_ rindex(const char *, int);
+char * _TLIBC_CDECL_ stpncpy(char *dest, const char *src, size_t n);
+int    _TLIBC_CDECL_ strcasecmp(const char *, const char *);
+int    _TLIBC_CDECL_ strncasecmp(const char *, const char *, size_t);
+
+int    _TLIBC_CDECL_ ffs(int);
+int    _TLIBC_CDECL_ ffsl(long int);
+int    _TLIBC_CDECL_ ffsll(long long int);
+
+char * _TLIBC_CDECL_ strtok_r(char *, const char *, char **);
+int    _TLIBC_CDECL_ strerror_r(int, char *, size_t);
+
+/*
+ * Deprecated Non-C99.
+ */
+_TLIBC_DEPRECATED_FUNCTION_(char * _TLIBC_CDECL_, strdup, const char *);
+_TLIBC_DEPRECATED_FUNCTION_(char * _TLIBC_CDECL_, stpcpy, char *dest, const char *src);
+
+__END_DECLS
+
+#endif /* _STRING_H_ */

--- a/core/build/headers/tlibc/sys/_types.h
+++ b/core/build/headers/tlibc/sys/_types.h
@@ -1,0 +1,138 @@
+/*	$OpenBSD: _types.h,v 1.2 2008/03/16 19:42:57 otto Exp $	*/
+
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)types.h	8.3 (Berkeley) 1/5/94
+ */
+
+#ifndef _SYS__TYPES_H_
+#define _SYS__TYPES_H_
+
+#include <sys/cdefs.h>
+/* 7.18.1.1 Exact-width integer types */
+typedef signed char         __int8_t;
+typedef unsigned char       __uint8_t;
+typedef short               __int16_t;
+typedef unsigned short      __uint16_t;
+typedef int                 __int32_t;
+typedef unsigned int        __uint32_t;
+#ifdef __x86_64__
+typedef long                __int64_t;
+typedef unsigned long       __uint64_t;
+#else
+typedef long long           __int64_t;
+typedef unsigned long long  __uint64_t;
+#endif
+
+/* 7.18.1.2 Minimum-width integer types */
+typedef __int8_t            __int_least8_t;
+typedef __uint8_t           __uint_least8_t;
+typedef __int16_t           __int_least16_t;
+typedef __uint16_t          __uint_least16_t;
+typedef __int32_t           __int_least32_t;
+typedef __uint32_t          __uint_least32_t;
+typedef __int64_t           __int_least64_t;
+typedef __uint64_t          __uint_least64_t;
+
+/* 7.18.1.3 Fastest minimum-width integer types */
+typedef __int8_t            __int_fast8_t;
+typedef __uint8_t           __uint_fast8_t;
+#ifdef __x86_64__
+/* Linux x86_64, from stdint.h */
+typedef long int            __int_fast16_t;
+typedef unsigned long int   __uint_fast16_t;
+typedef long int            __int_fast32_t;
+typedef unsigned long int   __uint_fast32_t;
+typedef long int            __int_fast64_t;
+typedef unsigned long int   __uint_fast64_t;
+#else 
+/* Android x86, and Linux x86 */
+typedef __int32_t           __int_fast16_t;
+typedef __uint32_t          __uint_fast16_t;
+typedef __int32_t           __int_fast32_t;
+typedef __uint32_t          __uint_fast32_t;
+typedef __int64_t           __int_fast64_t;
+typedef __uint64_t          __uint_fast64_t;
+#endif
+
+typedef long                __off_t;
+
+/* 7.18.1.4 Integer types capable of holding object pointers */
+#ifdef __i386__
+typedef __int32_t           __intptr_t;
+typedef __uint32_t          __uintptr_t;
+typedef __int32_t           __ptrdiff_t;
+/* Standard system types */
+typedef __uint32_t          __size_t;
+typedef __int32_t           __ssize_t;
+typedef long double         __double_t;
+typedef long double         __float_t;
+#else
+typedef __int64_t           __intptr_t;
+typedef __uint64_t          __uintptr_t;
+typedef __int64_t           __ptrdiff_t;
+
+/* Standard system types */
+typedef unsigned long       __size_t;
+typedef long                __ssize_t;
+typedef double              __double_t;
+typedef float               __float_t;
+
+#endif /* !__i386__ */
+
+typedef long                __clock_t;
+
+typedef long                __time_t;
+typedef __builtin_va_list   __va_list;
+typedef unsigned int        __wint_t;
+/* wctype_t and wctrans_t are defined in wchar.h */
+typedef unsigned long int   __wctype_t;
+typedef int *               __wctrans_t;
+
+/*
+ * mbstate_t is an opaque object to keep conversion state, during multibyte
+ * stream conversions. The content must not be referenced by user programs.
+ */
+/* For Linux, __mbstate_t is defined in wchar.h */
+typedef struct {
+    int __c;
+    union {
+        __wint_t __wc;
+        char __wcb[4];
+    } __v;
+} __mbstate_t;
+
+/* 7.18.1.5 Greatest-width integer types */
+typedef __int64_t           __intmax_t;
+typedef __uint64_t          __uintmax_t;
+
+#endif /* !_SYS__TYPES_H_ */
+
+
+

--- a/core/build/headers/tlibc/sys/cdefs.h
+++ b/core/build/headers/tlibc/sys/cdefs.h
@@ -1,0 +1,132 @@
+/*	$OpenBSD: cdefs.h,v 1.34 2012/08/14 20:11:37 matthew Exp $	*/
+/*	$NetBSD: cdefs.h,v 1.16 1996/04/03 20:46:39 christos Exp $	*/
+
+/*
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Berkeley Software Design, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)cdefs.h	8.7 (Berkeley) 1/21/94
+ */
+
+#ifndef _SYS_CDEFS_H_
+#define _SYS_CDEFS_H_
+
+/* Declaration field in C/C++ headers */
+#if defined(__cplusplus)
+# define __BEGIN_DECLS extern "C" {
+# define __END_DECLS }
+#else
+# define __BEGIN_DECLS
+# define __END_DECLS
+#endif
+
+#if defined(__STDC__) || defined(__cplusplus) 
+# define __CONCAT(x,y)  x ## y
+# define __STRING(x)    #x
+#else
+# define __CONCAT(x,y)  x/**/y
+# define __STRING(x)    "x"
+#endif
+/*
+ * Macro to test if we're using a specific version of gcc or later.
+ */
+#if defined __GNUC__ && defined __GNUC_MINOR_
+# define __GNUC_PREREQ__(ma, mi) \
+    ((__GNUC__ > (ma)) || (__GNUC__ == (ma) && __GNUC_MINOR__ >= (mi)))
+#else
+# define __GNUC_PREREQ__(ma, mi) 0
+#endif
+
+/* Calling Convention: cdecl */
+#define _TLIBC_CDECL_      
+
+/* Thread Directive */
+#define _TLIBC_THREAD_     /* __thread */
+
+/* Deprecated Warnings */
+#define _TLIBC_DEPRECATED_MSG(x)    __STRING(x)" is deprecated in tlibc."
+#define _TLIBC_DEPRECATED_(x)       __attribute__((deprecated(_TLIBC_DEPRECATED_MSG(x))))
+
+#ifndef _TLIBC_WARN_DEPRECATED_FUNCTIONS_
+# define _TLIBC_DEPRECATED_FUNCTION_(__ret, __func, ...)
+#else
+# define _TLIBC_DEPRECATED_FUNCTION_(__ret, __func, ...)    \
+    _TLIBC_DEPRECATED_(__func)  \
+    __ret __func(__VA_ARGS__)
+#endif
+
+/* Static analysis for printf format strings.
+ * _MSC_PRINTF_FORMAT_: MSVC SAL annotation for specifying format strings. 
+ * _GCC_PRINTF_FORMAT_(x, y): GCC declaring attribute for checking format strings.
+ *   x - index of the format string. In C++ non-static method, index 1 is reseved for 'this'.
+ *   y - index of first variadic agrument in '...'.
+ */
+#define _GCC_PRINTF_FORMAT_(x, y)  __attribute__((__format__ (printf, x, y)))
+
+/* Attribute - noreturn */
+#define _TLIBC_NORETURN_   __attribute__ ((__noreturn__))
+
+/*
+ * GNU C version 2.96 adds explicit branch prediction so that
+ * the CPU back-end can hint the processor and also so that
+ * code blocks can be reordered such that the predicted path
+ * sees a more linear flow, thus improving cache behavior, etc.
+ *
+ * The following two macros provide us with a way to utilize this
+ * compiler feature.  Use __predict_true() if you expect the expression
+ * to evaluate to true, and __predict_false() if you expect the
+ * expression to evaluate to false.
+ *
+ * A few notes about usage:
+ *
+ *	* Generally, __predict_false() error condition checks (unless
+ *	  you have some _strong_ reason to do otherwise, in which case
+ *	  document it), and/or __predict_true() `no-error' condition
+ *	  checks, assuming you want to optimize for the no-error case.
+ *
+ *	* Other than that, if you don't know the likelihood of a test
+ *	  succeeding from empirical or other `hard' evidence, don't
+ *	  make predictions.
+ *
+ *	* These are meant to be used in places that are run `a lot'.
+ *	  It is wasteful to make predictions in code that is run
+ *	  seldomly (e.g. at subsystem initialization time) as the
+ *	  basic block reordering that this affects can often generate
+ *	  larger code.
+ */
+#if defined(__GNUC__) && __GNUC_PREREQ__(2, 96)
+#define __predict_true(exp)	__builtin_expect(((exp) != 0), 1)
+#define __predict_false(exp)	__builtin_expect(((exp) != 0), 0)
+#else
+#define __predict_true(exp)	((exp) != 0)
+#define __predict_false(exp)	((exp) != 0)
+#endif
+
+#endif /* !_SYS_CDEFS_H_ */

--- a/core/build/headers/tlibc/sys/endian.h
+++ b/core/build/headers/tlibc/sys/endian.h
@@ -1,0 +1,54 @@
+/*	$OpenBSD: endian.h,v 1.18 2006/03/27 07:09:24 otto Exp $	*/
+
+/*-
+ * Copyright (c) 1997 Niklas Hallqvist.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Generic definitions for little- and big-endian systems.  Other endianesses
+ * has to be dealt with in the specific machine/endian.h file for that port.
+ *
+ * This file is meant to be included from a little- or big-endian port's
+ * machine/endian.h after setting _BYTE_ORDER to either 1234 for little endian
+ * or 4321 for big..
+ */
+
+#ifndef _SYS_ENDIAN_H_
+#define _SYS_ENDIAN_H_
+
+#define _LITTLE_ENDIAN  1234
+#define _BIG_ENDIAN     4321
+#define _PDP_ENDIAN     3412
+#define _BYTE_ORDER     _LITTLE_ENDIAN
+
+#define LITTLE_ENDIAN   _LITTLE_ENDIAN
+#define BIG_ENDIAN      _BIG_ENDIAN
+#define PDP_ENDIAN      _PDP_ENDIAN
+#define BYTE_ORDER      _BYTE_ORDER
+
+#define __BYTE_ORDER    _BYTE_ORDER
+#define __BIG_ENDIAN    _BIG_ENDIAN
+#define __LITTLE_ENDIAN _LITTLE_ENDIAN
+
+#endif /* _SYS_ENDIAN_H_ */
+

--- a/core/build/headers/tlibc/sys/limits.h
+++ b/core/build/headers/tlibc/sys/limits.h
@@ -1,0 +1,77 @@
+/* $OpenBSD: limits.h,v 1.8 2009/11/27 19:54:35 guenther Exp $ */
+/*
+ * Copyright (c) 2002 Marc Espie.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OPENBSD PROJECT AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OPENBSD
+ * PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _SYS_LIMITS_H_
+#define _SYS_LIMITS_H_
+
+#include <sys/cdefs.h>
+
+/* Common definitions for limits.h. */
+
+#define CHAR_BIT    8                           /* number of bits in a char */
+
+#define SCHAR_MAX   0x7f                        /* max value for a signed char */
+#define SCHAR_MIN   (-0x7f - 1)                 /* min value for a signed char */
+
+#define UCHAR_MAX   0xff                        /* max value for an unsigned char */
+#ifdef __CHAR_UNSIGNED__
+# define CHAR_MIN   0                           /* min value for a char */
+# define CHAR_MAX   0xff                        /* max value for a char */
+#else
+# define CHAR_MAX   0x7f
+# define CHAR_MIN   (-0x7f-1)
+#endif
+
+#define MB_LEN_MAX  1                           /* Allow UTF-8 (RFC 3629) */
+
+#define USHRT_MAX   0xffff                      /* max value for an unsigned short */
+#define SHRT_MAX    0x7fff                      /* max value for a short */
+#define SHRT_MIN    (-0x7fff-1)                 /* min value for a short */
+
+#define UINT_MAX    0xffffffffU                 /* max value for an unsigned int */
+#define INT_MAX     0x7fffffff                  /* max value for an int */
+#define INT_MIN     (-0x7fffffff-1)             /* min value for an int */
+
+#ifdef __x86_64__
+# define ULONG_MAX  0xffffffffffffffffUL        /* max value for unsigned long */
+# define LONG_MAX   0x7fffffffffffffffL         /* max value for a signed long */
+# define LONG_MIN   (-0x7fffffffffffffffL-1)    /* min value for a signed long */
+#else
+# define ULONG_MAX  0xffffffffUL                /* max value for an unsigned long */
+# define LONG_MAX   0x7fffffffL                 /* max value for a long */
+# define LONG_MIN   (-0x7fffffffL-1)            /* min value for a long */
+#endif
+
+#define ULLONG_MAX  0xffffffffffffffffULL       /* max value for unsigned long long */
+#define LLONG_MAX   0x7fffffffffffffffLL        /* max value for a signed long long */
+#define LLONG_MIN   (-0x7fffffffffffffffLL-1)   /* min value for a signed long long */
+
+#ifdef __x86_64__
+# define LONG_BIT   64
+#else
+# define LONG_BIT   32
+#endif
+
+#endif /* !_SYS_LIMITS_H_ */

--- a/core/build/headers/tlibc/sys/stdint.h
+++ b/core/build/headers/tlibc/sys/stdint.h
@@ -1,0 +1,260 @@
+/*	$OpenBSD: stdint.h,v 1.4 2006/12/10 22:17:55 deraadt Exp $	*/
+
+/*
+ * Copyright (c) 1997, 2005 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _SYS_STDINT_H_
+#define _SYS_STDINT_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+/* 7.18.1.1 Exact-width integer types (also in sys/types.h) */
+#ifndef _INT8_T_DEFINED_
+#define _INT8_T_DEFINED_
+typedef __int8_t        int8_t;
+#endif
+
+#ifndef _UINT8_T_DEFINED_
+#define _UINT8_T_DEFINED_
+typedef __uint8_t       uint8_t;
+#endif
+
+#ifndef _INT16_T_DEFINED_
+#define _INT16_T_DEFINED_
+typedef __int16_t       int16_t;
+#endif
+
+#ifndef _UINT16_T_DEFINED_
+#define _UINT16_T_DEFINED_
+typedef __uint16_t      uint16_t;
+#endif
+
+#ifndef _INT32_T_DEFINED_
+#define _INT32_T_DEFINED_
+typedef __int32_t       int32_t;
+#endif
+
+#ifndef _UINT32_T_DEFINED_
+#define _UINT32_T_DEFINED_
+typedef __uint32_t      uint32_t;
+#endif
+
+#ifndef _INT64_T_DEFINED_
+#define _INT64_T_DEFINED_
+typedef __int64_t       int64_t;
+#endif
+
+#ifndef _UINT64_T_DEFINED_
+#define _UINT64_T_DEFINED_
+typedef __uint64_t      uint64_t;
+#endif
+
+/* 7.18.1.2 Minimum-width integer types */
+typedef __int_least8_t      int_least8_t;
+typedef __uint_least8_t     uint_least8_t;
+typedef __int_least16_t     int_least16_t;
+typedef __uint_least16_t    uint_least16_t;
+typedef __int_least32_t     int_least32_t;
+typedef __uint_least32_t    uint_least32_t;
+typedef __int_least64_t     int_least64_t;
+typedef __uint_least64_t    uint_least64_t;
+
+/* 7.18.1.3 Fastest minimum-width integer types */
+typedef __int_fast8_t       int_fast8_t;
+typedef __uint_fast8_t      uint_fast8_t;
+typedef __int_fast16_t      int_fast16_t;
+typedef __uint_fast16_t     uint_fast16_t;
+typedef __int_fast32_t      int_fast32_t;
+typedef __uint_fast32_t     uint_fast32_t;
+typedef __int_fast64_t      int_fast64_t;
+typedef __uint_fast64_t     uint_fast64_t;
+
+/* 7.18.1.4 Integer types capable of holding object pointers */
+#ifndef _INTPTR_T_DEFINED_
+#define _INTPTR_T_DEFINED_
+typedef __intptr_t      intptr_t;
+#endif
+
+#ifndef _UINTPTR_T_DEFINED_
+#define _UINTPTR_T_DEFINED_
+typedef __uintptr_t     uintptr_t;
+#endif
+
+/* 7.18.1.5 Greatest-width integer types */
+typedef __intmax_t      intmax_t;
+typedef __uintmax_t     uintmax_t;
+
+//#if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS)
+/*
+ * 7.18.2 Limits of specified-width integer types.
+ *
+ * The following object-like macros specify the minimum and maximum limits
+ * of integer types corresponding to the typedef names defined above.
+ */
+
+/* 7.18.2.1 Limits of exact-width integer types */
+#define INT8_MIN        (-0x7f - 1)
+#define INT16_MIN       (-0x7fff - 1)
+#define INT32_MIN       (-0x7fffffff - 1)
+#ifdef __x86_64__
+#define INT64_MIN       (-0x7fffffffffffffffL - 1)
+#else
+#define INT64_MIN       (-0x7fffffffffffffffLL - 1)
+#endif
+
+#define INT8_MAX        0x7f
+#define INT16_MAX       0x7fff
+#define INT32_MAX       0x7fffffff
+#ifdef __x86_64__
+#define INT64_MAX       0x7fffffffffffffffL
+#else
+#define INT64_MAX       0x7fffffffffffffffLL
+#endif
+
+#define UINT8_MAX       0xff
+#define UINT16_MAX      0xffff
+#define UINT32_MAX      0xffffffffU
+#ifdef __x86_64__
+#define UINT64_MAX      0xffffffffffffffffUL
+#else
+#define UINT64_MAX      0xffffffffffffffffULL
+#endif
+
+/* 7.18.2.2 Limits of minimum-width integer types */
+#define INT_LEAST8_MIN      INT8_MIN
+#define INT_LEAST16_MIN     INT16_MIN
+#define INT_LEAST32_MIN     INT32_MIN
+#define INT_LEAST64_MIN     INT64_MIN
+
+#define INT_LEAST8_MAX      INT8_MAX
+#define INT_LEAST16_MAX     INT16_MAX
+#define INT_LEAST32_MAX     INT32_MAX
+#define INT_LEAST64_MAX     INT64_MAX
+
+#define UINT_LEAST8_MAX     UINT8_MAX
+#define UINT_LEAST16_MAX    UINT16_MAX
+#define UINT_LEAST32_MAX    UINT32_MAX
+#define UINT_LEAST64_MAX    UINT64_MAX
+
+/* 7.18.2.3 Limits of fastest minimum-width integer types */
+#define INT_FAST8_MIN       INT8_MIN
+#define INT_FAST16_MIN      INT16_MIN
+#define INT_FAST32_MIN      INT32_MIN
+#define INT_FAST64_MIN      INT64_MIN
+
+#define INT_FAST8_MAX       INT8_MAX
+#ifdef __x86_64__
+#define INT_FAST16_MAX      INT64_MAX
+#define INT_FAST32_MAX      INT64_MAX
+#else
+#define INT_FAST16_MAX      INT32_MAX
+#define INT_FAST32_MAX      INT32_MAX
+#endif
+#define INT_FAST64_MAX      INT64_MAX
+
+#define UINT_FAST8_MAX      UINT8_MAX
+#ifdef __x86_64__
+#define UINT_FAST16_MAX     UINT64_MAX
+#define UINT_FAST32_MAX     UINT64_MAX
+#else
+#define UINT_FAST16_MAX     UINT32_MAX
+#define UINT_FAST32_MAX     UINT32_MAX
+#endif
+#define UINT_FAST64_MAX     UINT64_MAX
+
+/* 7.18.2.4 Limits of integer types capable of holding object pointers */
+#ifdef __x86_64__
+#define INTPTR_MIN      INT64_MIN
+#define INTPTR_MAX      INT64_MAX
+#define UINTPTR_MAX     UINT64_MAX
+#else
+#define INTPTR_MIN      INT32_MIN
+#define INTPTR_MAX      INT32_MAX
+#define UINTPTR_MAX     UINT32_MAX
+#endif
+
+/* 7.18.2.5 Limits of greatest-width integer types */
+#define INTMAX_MIN      INT64_MIN
+#define INTMAX_MAX      INT64_MAX
+#define UINTMAX_MAX     UINT64_MAX
+
+/*
+ * 7.18.3 Limits of other integer types.
+ *
+ * The following object-like macros specify the minimum and maximum limits
+ * of integer types corresponding to types specified in other standard
+ * header files.
+ */
+
+/* Limits of ptrdiff_t */
+#define PTRDIFF_MIN     INTPTR_MIN
+#define PTRDIFF_MAX     INTPTR_MAX
+
+/* Limits of size_t (also in limits.h) */
+#ifndef SIZE_MAX
+#define SIZE_MAX        UINTPTR_MAX
+#endif
+
+/* Limits of wchar_t */
+# ifdef __WCHAR_MAX__
+#  define WCHAR_MAX __WCHAR_MAX__
+# else
+#  define WCHAR_MAX (2147483647)
+# endif
+# ifdef __WCHAR_MIN__
+#  define WCHAR_MIN __WCHAR_MIN__
+# elif L'\0' - 1 > 0
+#  define WCHAR_MIN L'\0'
+# else
+#  define WCHAR_MIN (-WCHAR_MAX - 1)
+# endif
+
+/* Limits of wint_t */
+# define WINT_MIN      (0u)
+# define WINT_MAX      (4294967295u)
+
+//#endif /* __cplusplus || __STDC_LIMIT_MACROS */
+
+//#if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS)
+/*
+ * 7.18.4 Macros for integer constants.
+ *
+ * The following function-like macros expand to integer constants
+ * suitable for initializing objects that have integer types corresponding
+ * to types defined in <stdint.h>.  The argument in any instance of
+ * these macros shall be a decimal, octal, or hexadecimal constant with
+ * a value that does not exceed the limits for the corresponding type.
+ */
+
+/* 7.18.4.1 Macros for minimum-width integer constants. */
+#define INT8_C(_c)      (_c)
+#define INT16_C(_c)     (_c)
+#define INT32_C(_c)     (_c)
+#define INT64_C(_c)     __CONCAT(_c, LL)
+
+#define UINT8_C(_c)     (_c)
+#define UINT16_C(_c)    (_c)
+#define UINT32_C(_c)    __CONCAT(_c, U)
+#define UINT64_C(_c)    __CONCAT(_c, ULL)
+
+/* 7.18.4.2 Macros for greatest-width integer constants. */
+#define INTMAX_C(_c)    __CONCAT(_c, LL)
+#define UINTMAX_C(_c)   __CONCAT(_c, ULL)
+
+//#endif /* __cplusplus || __STDC_CONSTANT_MACROS */
+
+#endif /* _SYS_STDINT_H_ */

--- a/core/build/headers/tlibc/sys/types.h
+++ b/core/build/headers/tlibc/sys/types.h
@@ -1,0 +1,128 @@
+/*	$OpenBSD: types.h,v 1.31 2008/03/16 19:42:57 otto Exp $	*/
+/*	$NetBSD: types.h,v 1.29 1996/11/15 22:48:25 jtc Exp $	*/
+
+/*-
+ * Copyright (c) 1982, 1986, 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)types.h	8.4 (Berkeley) 1/21/94
+ */
+
+#ifndef _SYS_TYPES_H_
+#define _SYS_TYPES_H_
+
+#include <sys/_types.h>
+#include <sys/endian.h>
+
+typedef unsigned char   u_char;
+typedef unsigned short  u_short;
+typedef unsigned int    u_int;
+typedef unsigned long   u_long;
+
+typedef unsigned char   unchar;     /* Sys V compatibility */
+typedef unsigned short  ushort;     /* Sys V compatibility */
+typedef unsigned int    uint;       /* Sys V compatibility */
+typedef unsigned long   ulong;      /* Sys V compatibility */
+
+#ifndef _INT8_T_DEFINED_
+#define _INT8_T_DEFINED_
+typedef __int8_t        int8_t;
+#endif
+
+#ifndef _UINT8_T_DEFINED_
+#define _UINT8_T_DEFINED_
+typedef __uint8_t       uint8_t;
+#endif
+
+#ifndef _INT16_T_DEFINED_
+#define _INT16_T_DEFINED_
+typedef __int16_t       int16_t;
+#endif
+
+#ifndef _UINT16_T_DEFINED_
+#define _UINT16_T_DEFINED_
+typedef __uint16_t      uint16_t;
+#endif
+
+#ifndef _INT32_T_DEFINED_
+#define _INT32_T_DEFINED_
+typedef __int32_t       int32_t;
+#endif
+
+#ifndef _UINT32_T_DEFINED_
+#define _UINT32_T_DEFINED_
+typedef __uint32_t      uint32_t;
+#endif
+
+#ifndef _INT64_T_DEFINED_
+#define _INT64_T_DEFINED_
+typedef __int64_t       int64_t;
+#endif
+
+#ifndef _UINT64_T_DEFINED_
+#define _UINT64_T_DEFINED_
+typedef __uint64_t      uint64_t;
+#endif
+
+#ifndef _INTPTR_T_DEFINED_
+#define _INTPTR_T_DEFINED_
+typedef __intptr_t      intptr_t;
+#endif
+
+#ifndef _UINTPTR_T_DEFINED_
+#define _UINTPTR_T_DEFINED_
+typedef __uintptr_t     uintptr_t;
+#endif
+
+/* BSD-style unsigned bits types */
+typedef __uint8_t       u_int8_t;
+typedef __uint16_t      u_int16_t;
+typedef __uint32_t      u_int32_t;
+typedef __uint64_t      u_int64_t;
+
+
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#endif
+
+#ifndef _SSIZE_T_DEFINED_
+#define _SSIZE_T_DEFINED_
+typedef __ssize_t   ssize_t;
+#endif
+
+#ifndef _OFF_T_DEFINED_
+#define _OFF_T_DEFINED_
+typedef __off_t     off_t;
+#endif
+
+#endif /* !_SYS_TYPES_H_ */

--- a/core/build/headers/tlibc/time.h
+++ b/core/build/headers/tlibc/time.h
@@ -1,0 +1,104 @@
+/*	$OpenBSD: time.h,v 1.18 2006/01/06 18:53:04 millert Exp $	*/
+/*	$NetBSD: time.h,v 1.9 1994/10/26 00:56:35 cgd Exp $	*/
+
+/*
+ * Copyright (c) 1989 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * (c) UNIX System Laboratories, Inc.
+ * All or some portions of this file are derived from material licensed
+ * to the University of California by American Telephone and Telegraph
+ * Co. or Unix System Laboratories, Inc. and are reproduced herein with
+ * the permission of UNIX System Laboratories, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)time.h	5.12 (Berkeley) 3/9/91
+ */
+
+#ifndef _TIME_H_
+#define _TIME_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL    0
+#else
+#define NULL    ((void *)0)
+#endif
+#endif
+
+#if !defined (_CLOCK_T_DEFINED_) && !defined (_CLOCK_T_DEFINED)
+#define _CLOCK_T_DEFINED_
+#define _CLOCK_T_DEFINED
+typedef __clock_t   clock_t;
+#endif
+
+#if !defined (_TIME_T_DEFINED_) && !defined (_TIME_T_DEFINED)
+#define _TIME_T_DEFINED_
+#define _TIME_T_DEFINED
+typedef __time_t    time_t;
+#endif
+
+#if !defined (_SIZE_T_DEFINED_) && !defined (_SIZE_T_DEFINED)
+#define _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED
+typedef __size_t    size_t;
+#endif
+
+#if !defined (_TM_DEFINED)
+#define _TM_DEFINED
+struct tm {
+    int tm_sec;     /* seconds after the minute [0-60] */
+    int tm_min;     /* minutes after the hour [0-59] */
+    int tm_hour;    /* hours since midnight [0-23] */
+    int tm_mday;    /* day of the month [1-31] */
+    int tm_mon;     /* months since January [0-11] */
+    int tm_year;    /* years since 1900 */
+    int tm_wday;    /* days since Sunday [0-6] */
+    int tm_yday;    /* days since January 1 [0-365] */
+    int tm_isdst;   /* Daylight Saving Time flag */
+    /* FIXME: naming issue exists on Fedora/Ubuntu */
+    long tm_gmtoff; /* offset from UTC in seconds */
+    char *tm_zone;  /* timezone abbreviation */
+};
+#endif
+
+__BEGIN_DECLS
+
+double _TLIBC_CDECL_ difftime(time_t, time_t);
+char * _TLIBC_CDECL_ asctime(const struct tm *);
+size_t _TLIBC_CDECL_ strftime(char *, size_t, const char *, const struct tm *);
+
+/*
+ * Non-C99
+ */
+char * _TLIBC_CDECL_ asctime_r(const struct tm *, char *);
+
+__END_DECLS
+
+#endif /* !_TIME_H_ */

--- a/core/build/headers/tlibc/unistd.h
+++ b/core/build/headers/tlibc/unistd.h
@@ -1,0 +1,61 @@
+/*	$OpenBSD: unistd.h,v 1.62 2008/06/25 14:58:54 millert Exp $ */
+/*	$NetBSD: unistd.h,v 1.26.4.1 1996/05/28 02:31:51 mrg Exp $	*/
+
+/*-
+ * Copyright (c) 1991 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)unistd.h	5.13 (Berkeley) 6/17/91
+ */
+
+#ifndef _UNISTD_H_
+#define	_UNISTD_H_
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+int getpagesize(void);
+
+void * _TLIBC_CDECL_ sbrk(intptr_t);
+
+/*
+ * Deprecated Non-C99. 
+ */
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execl, const char *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execlp, const char *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execle, const char *, const char *, ...);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execv, const char *, char * const *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execve, const char *, char * const *, char * const *);
+_TLIBC_DEPRECATED_FUNCTION_(int _TLIBC_CDECL_, execvp, const char *, char * const *);
+
+//_TLIBC_DEPRECATED_FUNCTION_(pid_t _TLIBC_CDECL_, fork, void); /* no pid_t */
+
+__END_DECLS
+
+#endif /* !_UNISTD_H_ */

--- a/core/build/headers/tlibc/wchar.h
+++ b/core/build/headers/tlibc/wchar.h
@@ -1,0 +1,143 @@
+/*	$OpenBSD: wchar.h,v 1.11 2010/07/24 09:58:39 guenther Exp $	*/
+/*	$NetBSD: wchar.h,v 1.16 2003/03/07 07:11:35 tshiozak Exp $	*/
+
+/*-
+ * Copyright (c)1999 Citrus Project,
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*-
+ * Copyright (c) 1999, 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Julian Coleman.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _WCHAR_H_
+#define _WCHAR_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+#include <sys/stdint.h> /* WCHAR_MAX/WCHAR_MIN */
+
+#ifndef NULL
+#ifdef __cplusplus
+#define NULL    0
+#else
+#define NULL    ((void *)0)
+#endif
+#endif
+
+#if !defined(_WCHAR_T_DEFINED_) && !defined(__cplusplus)
+#define _WCHAR_T_DEFINED_
+#ifndef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ int
+#endif
+typedef __WCHAR_TYPE__ wchar_t;
+#endif
+
+#ifndef _MBSTATE_T_DEFINED_
+#define _MBSTATE_T_DEFINED_
+typedef __mbstate_t mbstate_t;
+#endif
+
+#ifndef _WINT_T_DEFINED_
+#define _WINT_T_DEFINED_
+typedef __wint_t    wint_t;
+#endif
+
+#ifndef _SIZE_T_DEFINED_
+#define _SIZE_T_DEFINED_
+typedef __size_t    size_t;
+#endif
+
+#ifndef WEOF
+#define WEOF    ((wint_t)-1)
+#endif
+
+__BEGIN_DECLS
+
+wint_t      _TLIBC_CDECL_ btowc(int);
+int         _TLIBC_CDECL_ wctob(wint_t);
+size_t      _TLIBC_CDECL_ mbrlen(const char *, size_t, mbstate_t *);
+size_t      _TLIBC_CDECL_ mbrtowc(wchar_t *, const char *, size_t, mbstate_t *);
+int         _TLIBC_CDECL_ mbsinit(const mbstate_t *);
+size_t      _TLIBC_CDECL_ mbsrtowcs(wchar_t *, const char **, size_t, mbstate_t *);
+size_t      _TLIBC_CDECL_ wcrtomb(char *, wchar_t, mbstate_t *);
+wchar_t *   _TLIBC_CDECL_ wcschr(const wchar_t *, wchar_t);
+int         _TLIBC_CDECL_ wcscmp(const wchar_t *, const wchar_t *);
+int         _TLIBC_CDECL_ wcscoll(const wchar_t *, const wchar_t *);
+size_t      _TLIBC_CDECL_ wcscspn(const wchar_t *, const wchar_t *);
+size_t      _TLIBC_CDECL_ wcslen(const wchar_t *);
+wchar_t *   _TLIBC_CDECL_ wcsncat(wchar_t *, const wchar_t *, size_t);
+int         _TLIBC_CDECL_ wcsncmp(const wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wcsncpy(wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wcspbrk(const wchar_t *, const wchar_t *);
+wchar_t *   _TLIBC_CDECL_ wcsrchr(const wchar_t *, wchar_t);
+size_t      _TLIBC_CDECL_ wcsrtombs(char *, const wchar_t **, size_t, mbstate_t *);
+size_t      _TLIBC_CDECL_ wcsspn(const wchar_t *, const wchar_t *);
+wchar_t *   _TLIBC_CDECL_ wcsstr(const wchar_t *, const wchar_t *);
+wchar_t *   _TLIBC_CDECL_ wcstok(wchar_t *, const wchar_t *, wchar_t **);
+size_t      _TLIBC_CDECL_ wcsxfrm(wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wmemchr(const wchar_t *, wchar_t, size_t);
+int         _TLIBC_CDECL_ wmemcmp(const wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wmemcpy(wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wmemmove(wchar_t *, const wchar_t *, size_t);
+wchar_t *   _TLIBC_CDECL_ wmemset(wchar_t *, wchar_t, size_t);
+
+int         _TLIBC_CDECL_ swprintf(wchar_t *, size_t, const wchar_t *, ...);
+int         _TLIBC_CDECL_ vswprintf(wchar_t *, size_t, const wchar_t *, __va_list);
+
+long double         _TLIBC_CDECL_ wcstold (const wchar_t *, wchar_t **);
+long long           _TLIBC_CDECL_ wcstoll (const wchar_t *, wchar_t **, int);
+unsigned long long  _TLIBC_CDECL_ wcstoull (const wchar_t *, wchar_t **, int);
+
+/* leagcy version of wcsstr */
+wchar_t *   _TLIBC_CDECL_ wcswcs(const wchar_t *, const wchar_t *);
+
+__END_DECLS
+
+#endif /* !_WCHAR_H_ */

--- a/core/build/headers/tlibc/wctype.h
+++ b/core/build/headers/tlibc/wctype.h
@@ -1,0 +1,80 @@
+/*	$OpenBSD: wctype.h,v 1.5 2006/01/06 18:53:04 millert Exp $	*/
+/*	$NetBSD: wctype.h,v 1.5 2003/03/02 22:18:11 tshiozak Exp $	*/
+
+/*-
+ * Copyright (c)1999 Citrus Project,
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	citrus Id: wctype.h,v 1.4 2000/12/21 01:50:21 itojun Exp
+ */
+
+#ifndef _WCTYPE_H_
+#define _WCTYPE_H_
+
+#include <sys/cdefs.h>
+#include <sys/_types.h>
+
+#ifndef _WINT_T_DEFINED_
+#define _WINT_T_DEFINED_
+typedef __wint_t    wint_t;
+#endif
+
+#ifndef _WCTRANS_T_DEFINED_
+#define _WCTRANS_T_DEFINED_
+typedef __wctrans_t wctrans_t;
+#endif
+
+#ifndef _WCTYPE_T_DEFINED_
+#define _WCTYPE_T_DEFINED_
+typedef __wctype_t  wctype_t;
+#endif
+
+#ifndef WEOF
+#define WEOF    ((wint_t)-1)
+#endif
+
+__BEGIN_DECLS
+
+int       _TLIBC_CDECL_ iswalnum(wint_t);
+int       _TLIBC_CDECL_ iswalpha(wint_t);
+int       _TLIBC_CDECL_ iswblank(wint_t);
+int       _TLIBC_CDECL_ iswcntrl(wint_t);
+int       _TLIBC_CDECL_ iswdigit(wint_t);
+int       _TLIBC_CDECL_ iswgraph(wint_t);
+int       _TLIBC_CDECL_ iswlower(wint_t);
+int       _TLIBC_CDECL_ iswprint(wint_t);
+int       _TLIBC_CDECL_ iswpunct(wint_t);
+int       _TLIBC_CDECL_ iswspace(wint_t);
+int       _TLIBC_CDECL_ iswupper(wint_t);
+int       _TLIBC_CDECL_ iswxdigit(wint_t);
+int       _TLIBC_CDECL_ iswctype(wint_t, wctype_t);
+wint_t    _TLIBC_CDECL_ towctrans(wint_t, wctrans_t);
+wint_t    _TLIBC_CDECL_ towlower(wint_t);
+wint_t    _TLIBC_CDECL_ towupper(wint_t);
+wctrans_t _TLIBC_CDECL_ wctrans(const char *);
+wctype_t  _TLIBC_CDECL_ wctype(const char *);
+
+__END_DECLS
+
+#endif /* _WCTYPE_H_ */

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -26,6 +26,11 @@ mc-sgx-util = { path = "../../util", version = "=0.3.1-beta.0" }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 
+# `getrandom` is pulled in by `rand_core` we only need to access it directly when registering a custom spng,
+# `register_custom_getrandom`, which only happens for target_os = none
+[target.'cfg(target_os = "none")'.dependencies]
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }
+
 [dev-dependencies]
 rand = "0.8.5"
 yare = "1.0.1"

--- a/core/types/src/error.rs
+++ b/core/types/src/error.rs
@@ -2,7 +2,6 @@
 
 //! SGX Error types
 
-use core::result::Result as CoreResult;
 use mc_sgx_core_sys_types::sgx_status_t;
 use mc_sgx_util::{ResultFrom, ResultInto};
 
@@ -21,9 +20,6 @@ pub enum FfiError {
      * the known C enum values. */
     UnknownEnumValue(i64),
 }
-
-/// A convenience type alias for a `Result` which contains an [`Error`].
-pub type Result<T> = CoreResult<T, Error>;
 
 /// A enumeration of SGX errors.
 ///
@@ -242,7 +238,7 @@ pub enum Error {
 impl TryFrom<sgx_status_t> for Error {
     type Error = ();
 
-    fn try_from(src: sgx_status_t) -> CoreResult<Error, ()> {
+    fn try_from(src: sgx_status_t) -> Result<Error, ()> {
         match src {
             sgx_status_t::SGX_SUCCESS => Err(()),
 

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
     attestation_key::{AttestationKeyId, ExtendedAttestationKeyId},
     attributes::{Attributes, MiscellaneousAttribute, MiscellaneousSelect},
     config_id::ConfigId,
-    error::{Error, FfiError, Result},
+    error::{Error, FfiError},
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},
     measurement::{Measurement, MrEnclave, MrSigner},
     quote::QuoteNonce,
@@ -31,3 +31,19 @@ pub use crate::{
     svn::{ConfigSvn, CpuSvn, IsvSvn},
     target_info::TargetInfo,
 };
+
+// For targets that don't have a random number source we force it to always
+// fail.
+// Per https://docs.rs/getrandom/latest/getrandom/macro.register_custom_getrandom.html
+// this function will *only* be used if getrandom doesn't know of a native
+// secure spng
+#[cfg(target_os = "none")]
+use getrandom::register_custom_getrandom;
+
+#[cfg(target_os = "none")]
+register_custom_getrandom!(always_fail);
+
+#[cfg(target_os = "none")]
+fn always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}

--- a/tservice/src/report.rs
+++ b/tservice/src/report.rs
@@ -3,8 +3,10 @@
 
 use core::ptr;
 use mc_sgx_core_sys_types::sgx_report_t;
-use mc_sgx_core_types::{ReportData, Result, TargetInfo};
+use mc_sgx_core_types::{ReportData, TargetInfo};
 use mc_sgx_util::ResultInto;
+
+pub type Result<T> = ::core::result::Result<T, mc_sgx_core_types::Error>;
 
 /// Report operations that can be performed inside of an enclave
 pub trait Report: Sized {

--- a/urts/sys/types/src/lib.rs
+++ b/urts/sys/types/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022 The MobileCoin Foundation
 
 #![doc = include_str!("../README.md")]
+#![no_std]
 #![allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
 
 use mc_sgx_core_sys_types::{


### PR DESCRIPTION
Update the crates to build with the `thumbv7m-none-eabi` target using
only the `core` crate from std