### PR TITLE
Add `mc-sgx-dcap-types::Quote3::verify_nonce()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- `verify_nonce()`: `mc_sgx_dcap_types::Quote3` can verify a nonce matches that
+  which was provided in a `mc_sgx_core_types::ReportData`.
+
 ## [0.3.0] - 2022-10-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,8 @@ dependencies = [
  "mc-sgx-dcap-sys-types",
  "mc-sgx-util",
  "serde",
+ "sha2",
+ "subtle",
  "yare",
 ]
 

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -22,6 +22,8 @@ mc-sgx-core-types = { path = "../../core/types", version = "=0.3.1-beta.0" }
 mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.3.1-beta.0" }
 mc-sgx-util = { path = "../../util", version = "=0.3.1-beta.0" }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
+sha2 = { version = "0.10.6", default-features = false }
+subtle = { version = "2.4.1", default-features = false }
 
 [dev-dependencies]
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.3.1-beta.0" }

--- a/dcap/types/src/quote3.rs
+++ b/dcap/types/src/quote3.rs
@@ -4,11 +4,46 @@
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+use mc_sgx_core_types::{QuoteNonce, ReportData};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 
 /// Quote version 3
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Quote3<T> {
     bytes: T,
+}
+
+impl<T: AsRef<[u8]>> Quote3<T> {
+    /// Verify the provided `nonce` matches the one in `report_data`
+    ///
+    /// When a nonce is passed to the quote generation, a QE report will be
+    /// returned where the report data is `SHA256(nonce||quote)||32-0x00's`.
+    /// This will verify that the `nonce` and this quote instance match the
+    /// provided `report_data`
+    ///
+    /// > Note: This report data is *not* the QE report data in the quote, it is
+    ///     part of the report info returned from SGX SDK quote generation.
+    ///
+    /// # Arguments
+    /// * `nonce` - The nonce believed to be in the `report_data`
+    /// * `report_data` - The report data to verify matches the `nonce` and this
+    ///     quote instance.
+    ///
+    /// Returns `true` if the `report_data` matches the `nonce` and this quote
+    /// instance.  Returns `false` if they differ.
+    ///
+    pub fn verify_nonce(&self, nonce: &QuoteNonce, report_data: &ReportData) -> bool {
+        let mut hasher = Sha256::new();
+        hasher.update(nonce);
+        hasher.update(&self.bytes);
+        let hash = hasher.finalize();
+
+        let mut data = [0u8; ReportData::SIZE];
+        data[..hash.len()].copy_from_slice(hash.as_slice());
+
+        data.ct_eq(report_data.as_ref()).into()
+    }
 }
 
 impl<'a> From<&'a [u8]> for Quote3<&'a [u8]> {
@@ -27,10 +62,25 @@ impl From<Vec<u8>> for Quote3<Vec<u8>> {
 #[cfg(test)]
 mod test {
     extern crate std;
+
     #[cfg(feature = "alloc")]
     use std::vec;
 
     use super::*;
+
+    /// Provides ReportData for a given quote and nonce.
+    ///
+    /// This is meant to mimic the `sgx_report_data_t` in the QE report that
+    /// comes back in the `report_info` of `sgx_ql_get_quote()`
+    fn report_data_from_quote_and_nonce(quote: &Quote3<&[u8]>, nonce: &QuoteNonce) -> ReportData {
+        let mut report_data = [0u8; ReportData::SIZE];
+        let mut hasher = Sha256::new();
+        hasher.update(nonce);
+        hasher.update(quote.bytes);
+        let hash = hasher.finalize();
+        report_data[..hash.len()].copy_from_slice(hash.as_slice());
+        report_data.into()
+    }
 
     #[test]
     fn quote_from_slice() {
@@ -45,5 +95,50 @@ mod test {
         let bytes = vec![4u8; 6];
         let quote: Quote3<Vec<u8>> = bytes.clone().into();
         assert_eq!(quote.bytes, bytes);
+    }
+
+    #[test]
+    fn valid_quote_nonce_1_succeeds() {
+        let bytes = [3u8; 20].as_slice();
+        let quote: Quote3<&[u8]> = bytes.into();
+        let nonce = [1u8; QuoteNonce::SIZE].into();
+        let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
+        assert_eq!(quote.verify_nonce(&nonce, &report_data), true);
+    }
+
+    #[test]
+    fn valid_quote_nonce_5_succeeds() {
+        let bytes = [8u8; 60].as_slice();
+        let quote: Quote3<&[u8]> = bytes.into();
+        let nonce = [5u8; QuoteNonce::SIZE].into();
+        let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
+        assert_eq!(quote.verify_nonce(&nonce, &report_data), true);
+    }
+
+    #[test]
+    fn quote_nonce_off_by_one_fails() {
+        let bytes = [8u8; 60].as_slice();
+        let quote: Quote3<&[u8]> = bytes.into();
+        let mut nonce = [5u8; QuoteNonce::SIZE].into();
+        let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
+
+        let contents: &mut [u8] = nonce.as_mut();
+        contents[0] += 1;
+
+        assert_eq!(quote.verify_nonce(&nonce, &report_data), false);
+    }
+
+    #[test]
+    fn trailing_report_data_non_zero_fails() {
+        let bytes = [8u8; 60].as_slice();
+        let quote: Quote3<&[u8]> = bytes.into();
+        let nonce = [5u8; QuoteNonce::SIZE].into();
+        let mut report_data = report_data_from_quote_and_nonce(&quote, &nonce);
+
+        let contents: &mut [u8] = report_data.as_mut();
+        let hash_size = 32;
+        contents[hash_size] += 1;
+
+        assert_eq!(quote.verify_nonce(&nonce, &report_data), false);
     }
 }


### PR DESCRIPTION
`Quote3` can now verify a nonce matches one provided in a `ReportData`.