### PR TITLE
Update Quote3 to ensure correct version and size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "mc-sgx-util",
  "serde",
  "sha2",
+ "static_assertions",
  "subtle",
  "yare",
 ]
@@ -1110,6 +1111,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/dcap/ql/src/lib.rs
+++ b/dcap/ql/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 mod quote3;
 mod quote_enclave;
 
-use mc_sgx_dcap_types::QlError;
+use mc_sgx_dcap_types::{QlError, Quote3Error};
 pub use quote3::TryFromReport;
 pub use quote_enclave::{LoadPolicyInitializer, PathInitializer, QeTargetInfo};
 
@@ -28,6 +28,14 @@ pub enum Error {
     PathLengthTooLong(String),
     /// The quoting enclave load policy has already been initialized
     LoadPolicyInitialized,
+    /// Error from Quote3 interface
+    Quote3(Quote3Error),
+}
+
+impl From<Quote3Error> for Error {
+    fn from(src: Quote3Error) -> Self {
+        Self::Quote3(src)
+    }
 }
 
 impl From<QlError> for Error {

--- a/dcap/ql/src/quote3.rs
+++ b/dcap/ql/src/quote3.rs
@@ -41,7 +41,7 @@ pub trait TryFromReport {
             )
         }
         .into_result()?;
-        Ok(quote.into())
+        Ok(quote.try_into()?)
     }
 }
 

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -23,6 +23,7 @@ mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.3.1-beta.0" }
 mc-sgx-util = { path = "../../util", version = "=0.3.1-beta.0" }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.10.6", default-features = false }
+static_assertions = "1.1.0"
 subtle = { version = "2.4.1", default-features = false }
 
 [dev-dependencies]

--- a/dcap/types/src/lib.rs
+++ b/dcap/types/src/lib.rs
@@ -13,7 +13,10 @@ mod quoting_enclave;
 mod request_policy;
 
 pub use crate::{
-    error::QlError, quote3::Quote3, quoting_enclave::ReportInfo, request_policy::RequestPolicy,
+    error::QlError,
+    quote3::{Error as Quote3Error, Quote3},
+    quoting_enclave::ReportInfo,
+    request_policy::RequestPolicy,
 };
 
 // TODO:

--- a/dcap/types/src/quote3.rs
+++ b/dcap/types/src/quote3.rs
@@ -4,9 +4,42 @@
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+use core::mem;
 use mc_sgx_core_types::{QuoteNonce, ReportData};
+use mc_sgx_dcap_sys_types::{sgx_ql_ecdsa_sig_data_t, sgx_quote3_t};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
+
+// The size of the quote bytes. Not including the authentication or
+// certification data.
+const QUOTE_SIZE: usize =
+    mem::size_of::<sgx_quote3_t>() + mem::size_of::<sgx_ql_ecdsa_sig_data_t>();
+
+// The offset to the authentication data
+const AUTH_DATA_OFFSET: usize = QUOTE_SIZE;
+
+/// The minimum size of a byte array to contain a [`Quote3`]
+///
+// 8 is from the 2 bytes for QE authentication data size and 2(type) + 4(size)
+// for QE certification data
+pub const MIN_QUOTE_SIZE: usize = QUOTE_SIZE + 8;
+
+/// Errors interacting with a Quote3
+#[derive(Clone, Debug, displaydoc::Display, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Error {
+    /** Quote buffer too small; actual size: {actual_size}, required size
+     * {required_size} */
+    #[allow(missing_docs)]
+    InvalidInputLength {
+        required_size: usize,
+        actual_size: usize,
+    },
+    /// Invalid quote version: {0}, should be: 3
+    InvalidVersion(usize),
+}
+
+type Result<T> = ::core::result::Result<T, Error>;
 
 /// Quote version 3
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -44,34 +77,217 @@ impl<T: AsRef<[u8]>> Quote3<T> {
 
         data.ct_eq(report_data.as_ref()).into()
     }
+
+    /// Try to get a [`Quote3`] from `bytes`
+    ///
+    /// This will ensure `bytes` is for the correct quote type and that it's
+    /// large enough to represent the quote.
+    ///
+    /// # Arguments:
+    /// * `bytes` - The bytes to interpret as a [`Quote3`]
+    ///
+    /// # Errors:
+    /// * [`Error::InvalidInputLength`] if the length of `bytes` is not large
+    ///   enough to represent the [`Quote3`].
+    /// * [`Error::InvalidVersion`] if the `bytes` is for a different quote
+    ///   version.
+    fn try_from_bytes(bytes: T) -> Result<Self> {
+        let ref_bytes = bytes.as_ref();
+        let bytes_length = ref_bytes.len();
+        if bytes_length < MIN_QUOTE_SIZE {
+            return Err(Error::InvalidInputLength {
+                required_size: MIN_QUOTE_SIZE,
+                actual_size: bytes_length,
+            });
+        }
+
+        // This shouldn't fail since we checked for `MIN_QUOTE_SIZE` above.
+        let version = u16_from_bytes(ref_bytes, 0)? as usize;
+        if version != 3 {
+            return Err(Error::InvalidVersion(version));
+        }
+
+        let auth_data = AuthenticationData::try_from(&bytes.as_ref()[AUTH_DATA_OFFSET..]).map_err(
+            |e| match e {
+                Error::InvalidInputLength {
+                    required_size,
+                    actual_size,
+                } => {
+                    let required_size = required_size + QUOTE_SIZE;
+                    let actual_size = actual_size + QUOTE_SIZE;
+                    Error::InvalidInputLength {
+                        required_size,
+                        actual_size,
+                    }
+                }
+                e => e,
+            },
+        )?;
+
+        let quote_with_auth_size = QUOTE_SIZE + auth_data.size();
+
+        let _ =
+            CertificationData::try_from(&bytes.as_ref()[quote_with_auth_size..]).map_err(|e| {
+                match e {
+                    Error::InvalidInputLength {
+                        required_size,
+                        actual_size,
+                    } => {
+                        let required_size = required_size + quote_with_auth_size;
+                        let actual_size = actual_size + quote_with_auth_size;
+                        Error::InvalidInputLength {
+                            required_size,
+                            actual_size,
+                        }
+                    }
+                    e => e,
+                }
+            })?;
+
+        Ok(Self { bytes })
+    }
 }
 
-impl<'a> From<&'a [u8]> for Quote3<&'a [u8]> {
-    fn from(bytes: &'a [u8]) -> Self {
-        Self { bytes }
+impl<'a> TryFrom<&'a [u8]> for Quote3<&'a [u8]> {
+    type Error = Error;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
+        Self::try_from_bytes(bytes)
     }
 }
 
 #[cfg(feature = "alloc")]
-impl From<Vec<u8>> for Quote3<Vec<u8>> {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self { bytes }
+impl TryFrom<Vec<u8>> for Quote3<Vec<u8>> {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self> {
+        Self::try_from_bytes(bytes)
     }
+}
+
+/// The Quoting enclave authentication data
+///
+/// Table 8 of
+/// <https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf>.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct AuthenticationData<'a> {
+    bytes: &'a [u8],
+    // Since this has to be read always we unpack for availability.
+    // This is the `size` field, *not* the length of `bytes`.
+    data_size: usize,
+}
+
+impl<'a> TryFrom<&'a [u8]> for AuthenticationData<'a> {
+    type Error = Error;
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
+        let bytes_length = bytes.len();
+
+        let data_size = u16_from_bytes(bytes, 0)? as usize;
+
+        let needed_size = data_size + mem::size_of::<u16>();
+        if bytes_length < needed_size {
+            Err(Error::InvalidInputLength {
+                required_size: needed_size,
+                actual_size: bytes_length,
+            })
+        } else {
+            Ok(Self { bytes, data_size })
+        }
+    }
+}
+
+impl<'a> AuthenticationData<'a> {
+    pub fn size(&self) -> usize {
+        self.data_size + mem::size_of::<u16>()
+    }
+}
+
+/// The Quoting enclave certification data
+///
+/// Table 9 of
+/// <https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf>.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct CertificationData<'a> {
+    bytes: &'a [u8],
+    // Since these are small and the `size` has to be read we always unpack
+    // for availability.
+    data_type: u16,
+    // This is the size of the data field, *not* the size of `bytes`
+    data_size: usize,
+}
+
+impl<'a> TryFrom<&'a [u8]> for CertificationData<'a> {
+    type Error = Error;
+    fn try_from(bytes: &'a [u8]) -> Result<Self> {
+        let bytes_length = bytes.len();
+
+        // type (2 bytes) + size (4 bytes)
+        let mut needed_size = mem::size_of::<u16>() + mem::size_of::<u32>();
+
+        if bytes_length < needed_size {
+            return Err(Error::InvalidInputLength {
+                required_size: needed_size,
+                actual_size: bytes_length,
+            });
+        }
+
+        // These shouldn't fail since we ensured the length up above
+        let data_type = u16_from_bytes(bytes, 0)?;
+        let data_size = u32_from_bytes(bytes, mem::size_of::<u16>())? as usize;
+
+        needed_size += data_size;
+        if bytes_length < needed_size {
+            Err(Error::InvalidInputLength {
+                required_size: needed_size,
+                actual_size: bytes_length,
+            })
+        } else {
+            Ok(Self {
+                bytes,
+                data_type,
+                data_size,
+            })
+        }
+    }
+}
+
+fn u32_from_bytes(bytes: &[u8], offset: usize) -> Result<u32> {
+    const SIZE: usize = mem::size_of::<u32>();
+    let mut u32_bytes = [0u8; SIZE];
+    let end = offset + SIZE;
+    let copy_bytes = bytes.get(offset..end).ok_or(Error::InvalidInputLength {
+        required_size: end,
+        actual_size: bytes.len(),
+    })?;
+    u32_bytes.copy_from_slice(copy_bytes);
+    Ok(u32::from_le_bytes(u32_bytes))
+}
+
+fn u16_from_bytes(bytes: &[u8], offset: usize) -> Result<u16> {
+    const SIZE: usize = mem::size_of::<u16>();
+    let mut u16_bytes = [0u8; SIZE];
+    let end = offset + SIZE;
+    let copy_bytes = bytes.get(offset..end).ok_or(Error::InvalidInputLength {
+        required_size: end,
+        actual_size: bytes.len(),
+    })?;
+    u16_bytes.copy_from_slice(copy_bytes);
+    Ok(u16::from_le_bytes(u16_bytes))
 }
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-
-    #[cfg(feature = "alloc")]
-    use std::vec;
-
     use super::*;
+    use yare::parameterized;
 
     /// Provides ReportData for a given quote and nonce.
     ///
     /// This is meant to mimic the `sgx_report_data_t` in the QE report that
     /// comes back in the `report_info` of `sgx_ql_get_quote()`
+    ///
+    /// # Arguments:
+    /// * `quote` - The quote to generate the [`ReportData`] from.
+    /// * `nonce` - The nonce to generate the [`ReportData`] from.
     fn report_data_from_quote_and_nonce(quote: &Quote3<&[u8]>, nonce: &QuoteNonce) -> ReportData {
         let mut report_data = [0u8; ReportData::SIZE];
         let mut hasher = Sha256::new();
@@ -82,25 +298,148 @@ mod test {
         report_data.into()
     }
 
+    /// Set the minimum fields in `bytes` to be interpreted as a quote3.
+    ///
+    /// In particular this will:
+    /// - Set the version to `3`.
+    /// - Zero the tail of `bytes`.  This ensures that the dynamically sized
+    ///   trailing structures show up as empty
+    ///
+    /// # Arguments:
+    /// * `bytes` -  the bytes to update to be a valid quote structure. `bytes`
+    ///   needs have a length of at least `MIN_QUOTE_SIZE`.
+    ///
+    /// Returns the updated version of `bytes`.
+    fn quotify_bytes(bytes: &mut [u8]) -> &mut [u8] {
+        let version = 3u16.to_le_bytes();
+        bytes[..mem::size_of::<u16>()].copy_from_slice(&version);
+
+        for byte in &mut bytes[AUTH_DATA_OFFSET..] {
+            *byte = 0;
+        }
+        bytes
+    }
+
     #[test]
     fn quote_from_slice() {
-        let bytes = [4u8; 6].as_slice();
-        let quote: Quote3<&[u8]> = bytes.into();
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote = Quote3::try_from(bytes.as_ref()).unwrap();
+        assert_eq!(quote.bytes, bytes);
+    }
+
+    #[parameterized(
+    version_2 = {2},
+    version_4 = {4},
+    )]
+    fn quote_with_wrong_version(version: u16) {
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+
+        let version_bytes = version.to_le_bytes();
+        bytes[..mem::size_of::<u16>()].copy_from_slice(&version_bytes);
+
+        assert_eq!(
+            Quote3::try_from(bytes.as_ref()),
+            Err(Error::InvalidVersion(version as usize))
+        );
+    }
+
+    #[test]
+    fn quote_too_small_for_signature() {
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        assert_eq!(
+            Quote3::try_from(&bytes[..bytes.len() - 1]),
+            Err(Error::InvalidInputLength {
+                required_size: MIN_QUOTE_SIZE,
+                actual_size: MIN_QUOTE_SIZE - 1
+            })
+        );
+    }
+
+    #[test]
+    fn quote_with_authentication_data() {
+        let mut binding = [4u8; MIN_QUOTE_SIZE + 1];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        bytes[AUTH_DATA_OFFSET] = 1;
+        let quote = Quote3::try_from(bytes.as_ref()).unwrap();
+        assert_eq!(quote.bytes, bytes);
+    }
+
+    #[test]
+    fn quote_too_small_for_authentication_data() {
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        bytes[AUTH_DATA_OFFSET] = 1;
+        assert_eq!(
+            Quote3::try_from(bytes.as_ref()),
+            Err(Error::InvalidInputLength {
+                required_size: MIN_QUOTE_SIZE + 1,
+                actual_size: MIN_QUOTE_SIZE
+            })
+        );
+    }
+
+    #[test]
+    fn quote_with_certification_data() {
+        let mut binding = [4u8; MIN_QUOTE_SIZE + 1];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        // 2 (auth data size) + 2 (cert data type )
+        bytes[QUOTE_SIZE + 2 + 2] = 1;
+        let quote = Quote3::try_from(bytes.as_ref()).unwrap();
+        assert_eq!(quote.bytes, bytes);
+    }
+
+    #[test]
+    fn quote_too_small_for_certification_data() {
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        // 2 (auth data size) + 2 (cert data type )
+        bytes[QUOTE_SIZE + 2 + 2] = 1;
+        assert_eq!(
+            Quote3::try_from(bytes.as_ref()),
+            Err(Error::InvalidInputLength {
+                required_size: MIN_QUOTE_SIZE + 1,
+                actual_size: MIN_QUOTE_SIZE
+            })
+        );
+    }
+
+    #[test]
+    fn quote_with_auth_and_cert_data() {
+        // 2 (cert data type ) + 4 (cert data size)
+        const CERT_FIELD_CONSTANT_SIZE: usize = 6;
+
+        // The authentication data wll be so large that it exceeds
+        // `MIN_QUOTE_SIZE`, thus pushing the certification data fully outside
+        // of the `MIN_QUOTE_SIZE`
+        let mut binding = [5u8; MIN_QUOTE_SIZE + CERT_FIELD_CONSTANT_SIZE + 1];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+
+        bytes[AUTH_DATA_OFFSET] = CERT_FIELD_CONSTANT_SIZE as u8;
+
+        // 2 (cert data type )
+        bytes[MIN_QUOTE_SIZE + 2] = 1;
+
+        let quote = Quote3::try_from(bytes.as_ref()).unwrap();
         assert_eq!(quote.bytes, bytes);
     }
 
     #[cfg(feature = "alloc")]
     #[test]
     fn quote_from_vec() {
-        let bytes = vec![4u8; 6];
-        let quote: Quote3<Vec<u8>> = bytes.clone().into();
+        let mut binding = [4u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote: Quote3<Vec<u8>> = bytes.to_vec().try_into().unwrap();
         assert_eq!(quote.bytes, bytes);
     }
 
     #[test]
     fn valid_quote_nonce_1_succeeds() {
-        let bytes = [3u8; 20].as_slice();
-        let quote: Quote3<&[u8]> = bytes.into();
+        let mut binding = [3u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote = bytes.as_ref().try_into().unwrap();
         let nonce = [1u8; QuoteNonce::SIZE].into();
         let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
         assert_eq!(quote.verify_nonce(&nonce, &report_data), true);
@@ -108,8 +447,9 @@ mod test {
 
     #[test]
     fn valid_quote_nonce_5_succeeds() {
-        let bytes = [8u8; 60].as_slice();
-        let quote: Quote3<&[u8]> = bytes.into();
+        let mut binding = [8u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote = bytes.as_ref().try_into().unwrap();
         let nonce = [5u8; QuoteNonce::SIZE].into();
         let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
         assert_eq!(quote.verify_nonce(&nonce, &report_data), true);
@@ -117,8 +457,9 @@ mod test {
 
     #[test]
     fn quote_nonce_off_by_one_fails() {
-        let bytes = [8u8; 60].as_slice();
-        let quote: Quote3<&[u8]> = bytes.into();
+        let mut binding = [8u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote = bytes.as_ref().try_into().unwrap();
         let mut nonce = [5u8; QuoteNonce::SIZE].into();
         let report_data = report_data_from_quote_and_nonce(&quote, &nonce);
 
@@ -130,8 +471,9 @@ mod test {
 
     #[test]
     fn trailing_report_data_non_zero_fails() {
-        let bytes = [8u8; 60].as_slice();
-        let quote: Quote3<&[u8]> = bytes.into();
+        let mut binding = [8u8; MIN_QUOTE_SIZE];
+        let bytes = quotify_bytes(binding.as_mut_slice());
+        let quote = bytes.as_ref().try_into().unwrap();
         let nonce = [5u8; QuoteNonce::SIZE].into();
         let mut report_data = report_data_from_quote_and_nonce(&quote, &nonce);
 


### PR DESCRIPTION
Previously Quote3 was using the `From` trait and did not verify that the
source bytes were sufficient to represent a Quote3. Now Quote3 uitilizes
the `TryFrom` trait and errors if the source bytes are not large enough
or do not represent a version 3 quote.