### PR TITLE
Add `From` bytes for `QuoteHeader`

### DIFF
--- a/dcap/types/src/quote_header.rs
+++ b/dcap/types/src/quote_header.rs
@@ -2,6 +2,7 @@
 
 //! This module provides types related to Quote v3
 
+use core::mem;
 use mc_sgx_core_types::{new_type_accessors_impls, Algorithm, FfiError, IsvSvn};
 use mc_sgx_dcap_sys_types::sgx_quote_header_t;
 
@@ -54,9 +55,88 @@ new_type_accessors_impls! {
     QuoteHeader, sgx_quote_header_t;
 }
 
+impl From<[u8; mem::size_of::<sgx_quote_header_t>()]> for QuoteHeader {
+    fn from(bytes: [u8; mem::size_of::<sgx_quote_header_t>()]) -> Self {
+        // A note about the `expect()` calls.  This size is specified in the
+        // signature and there are unit tests ensuring the extraction from a
+        // byte array.  The values should not fail to extract due to size
+        // issues.
+        let mut header = Self::default();
+        header.0.version =
+            u16::from_le_bytes(bytes[..2].try_into().expect("Failed to extract `version`"));
+        header.0.att_key_type = u16::from_le_bytes(
+            bytes[2..4]
+                .try_into()
+                .expect("Failed to extract `att_key_type`"),
+        );
+        header.0.att_key_data_0 = u32::from_le_bytes(
+            bytes[4..8]
+                .try_into()
+                .expect("Failed to extract `att_key_data_0`"),
+        );
+        header.0.qe_svn =
+            u16::from_le_bytes(bytes[8..10].try_into().expect("Failed to extract `qe_svn`"));
+        header.0.pce_svn = u16::from_le_bytes(
+            bytes[10..12]
+                .try_into()
+                .expect("Failed to extract `pce_svn`"),
+        );
+        header.0.vendor_id = bytes[12..28]
+            .try_into()
+            .expect("Failed to extract `vendor_id`");
+        header.0.user_data = bytes[28..]
+            .try_into()
+            .expect("Failed to extract `user_data`");
+        header
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
+    use core::slice;
+
+    fn header_1() -> sgx_quote_header_t {
+        sgx_quote_header_t {
+            version: 1,
+            att_key_type: Algorithm::EcdsaP256 as u16,
+            att_key_data_0: 2,
+            qe_svn: IsvSvn::from(4).into(),
+            pce_svn: IsvSvn::from(5).into(),
+            vendor_id: [6u8; 16],
+            user_data: [7u8; 20],
+        }
+    }
+
+    fn header_2() -> sgx_quote_header_t {
+        sgx_quote_header_t {
+            version: 3,
+            att_key_type: Algorithm::EcdsaP384 as u16,
+            att_key_data_0: 5,
+            qe_svn: IsvSvn::from(6).into(),
+            pce_svn: IsvSvn::from(7).into(),
+            vendor_id: [8u8; 16],
+            user_data: [9u8; 20],
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn header_to_bytes(header: sgx_quote_header_t) -> [u8; mem::size_of::<sgx_quote_header_t>()] {
+        // SAFETY: This is a test only function. The size of `header` is used
+        // for reinterpretation of `header` into a byte slice. The slice is
+        // copied from prior to the leaving of this function ensuring the raw
+        // pointer is not persisted.
+        let alias_bytes: &[u8] = unsafe {
+            slice::from_raw_parts(
+                &header as *const sgx_quote_header_t as *const u8,
+                mem::size_of::<sgx_quote_header_t>(),
+            )
+        };
+        let mut bytes: [u8; mem::size_of::<sgx_quote_header_t>()] =
+            [0; mem::size_of::<sgx_quote_header_t>()];
+        bytes.copy_from_slice(alias_bytes);
+        bytes
+    }
 
     #[test]
     fn default_quote_header() {
@@ -72,17 +152,7 @@ mod test {
 
     #[test]
     fn quote_header_from_sgx() {
-        let sgx_header = sgx_quote_header_t {
-            version: 1,
-            att_key_type: Algorithm::EcdsaP256 as u16,
-            att_key_data_0: 2,
-            qe_svn: IsvSvn::from(4).into(),
-            pce_svn: IsvSvn::from(5).into(),
-            vendor_id: [6u8; 16],
-            user_data: [7u8; 20],
-        };
-
-        let header: QuoteHeader = sgx_header.into();
+        let header: QuoteHeader = header_1().into();
         assert_eq!(header.version(), 1);
         assert_eq!(header.attestation_key_type().unwrap(), Algorithm::EcdsaP256);
         assert_eq!(header.attestation_key_raw(), 2);
@@ -90,5 +160,31 @@ mod test {
         assert_eq!(header.pce_svn(), IsvSvn::from(5));
         assert_eq!(header.vendor_id(), [6u8; 16]);
         assert_eq!(header.user_data(), [7u8; 20]);
+    }
+
+    #[test]
+    fn header_1_from_bytes() {
+        let bytes = header_to_bytes(header_1());
+        let header = QuoteHeader::from(bytes);
+        assert_eq!(header.version(), 1);
+        assert_eq!(header.attestation_key_type().unwrap(), Algorithm::EcdsaP256);
+        assert_eq!(header.attestation_key_raw(), 2);
+        assert_eq!(header.qe_svn(), IsvSvn::from(4));
+        assert_eq!(header.pce_svn(), IsvSvn::from(5));
+        assert_eq!(header.vendor_id(), [6u8; 16]);
+        assert_eq!(header.user_data(), [7u8; 20]);
+    }
+
+    #[test]
+    fn header_2_from_bytes() {
+        let bytes = header_to_bytes(header_2());
+        let header = QuoteHeader::from(bytes);
+        assert_eq!(header.version(), 3);
+        assert_eq!(header.attestation_key_type().unwrap(), Algorithm::EcdsaP384);
+        assert_eq!(header.attestation_key_raw(), 5);
+        assert_eq!(header.qe_svn(), IsvSvn::from(6));
+        assert_eq!(header.pce_svn(), IsvSvn::from(7));
+        assert_eq!(header.vendor_id(), [8u8; 16]);
+        assert_eq!(header.user_data(), [9u8; 20]);
     }
 }


### PR DESCRIPTION
Add functionality to unpack a `QuoteHeader` from a byte slice.