### PR TITLE
Change `mc-sgx-core-types::ReportBody` to use TryFrom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "getrandom",
  "mc-sgx-core-sys-types",
  "mc-sgx-util",
+ "nom",
  "rand",
  "rand_core",
  "serde",

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "1.3.2"
 displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.3.1-beta.0" }
 mc-sgx-util = { path = "../../util", version = "=0.3.1-beta.0" }
+nom = { version = "7.1.1", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
 

--- a/core/types/src/error.rs
+++ b/core/types/src/error.rs
@@ -21,6 +21,14 @@ pub enum FfiError {
     UnknownEnumValue(i64),
 }
 
+impl From<nom::Err<nom::error::Error<&[u8]>>> for FfiError {
+    fn from(_src: nom::Err<nom::error::Error<&[u8]>>) -> Self {
+        // This is knowingly reducing the error information. The only failures
+        // arise from the parsed input not being of sufficient size.
+        FfiError::InvalidInputLength
+    }
+}
+
 /// A enumeration of SGX errors.
 ///
 /// Those listed here are the ones which are identified in the `sgx_status_t`

--- a/core/types/src/quote.rs
+++ b/core/types/src/quote.rs
@@ -5,11 +5,9 @@ use crate::{
     attestation_key::QuoteSignatureKind, impl_newtype_for_bytestruct, new_type_accessors_impls,
     report::Report, FfiError, IsvSvn, ReportBody, TargetInfo,
 };
-use core::mem;
 use mc_sgx_core_sys_types::{
     sgx_basename_t, sgx_epid_group_id_t, sgx_platform_info_t, sgx_qe_report_info_t,
-    sgx_quote_nonce_t, sgx_quote_sign_type_t, sgx_report_body_t, sgx_update_info_bit_t,
-    SGX_PLATFORM_INFO_SIZE,
+    sgx_quote_nonce_t, sgx_quote_sign_type_t, sgx_update_info_bit_t, SGX_PLATFORM_INFO_SIZE,
 };
 
 /// Quoting Enclave Report Info
@@ -182,11 +180,8 @@ pub trait BaseQuote {
     }
 
     /// Report body
-    fn report_body(&self) -> ReportBody {
-        let bytes: [u8; mem::size_of::<sgx_report_body_t>()] = self.raw_quote().bytes[48..432]
-            .try_into()
-            .expect("Quote bytes aren't big enough to hold `report_body`");
-        bytes.into()
+    fn report_body(&self) -> Result<ReportBody, FfiError> {
+        self.raw_quote().bytes[48..432].try_into()
     }
 }
 
@@ -323,7 +318,7 @@ mod test {
 
         let mut report_body = sgx_report_body_t::default();
         report_body.misc_select = 18;
-        assert_eq!(quote.report_body(), report_body.into());
+        assert_eq!(quote.report_body().unwrap(), report_body.into());
     }
 
     #[test]
@@ -345,7 +340,7 @@ mod test {
 
         let mut report_body = sgx_report_body_t::default();
         report_body.misc_select = 28;
-        assert_eq!(quote.report_body(), report_body.into());
+        assert_eq!(quote.report_body().unwrap(), report_body.into());
     }
 
     #[test]


### PR DESCRIPTION
Previously `mc-sgx-core-types::ReportBody` used the from trait for a
fixed size slice. Now the `mc-sgx-core-types::ReportBody` uses the
TryFrom trait on a dynamically sized slice.

The fixed sized slice required copying from a dynamic buffer into a
temporary fixed sized buffer in order to fullfil the compile
time constraint of the fixed size.