### PR TITLE
Remove overriding profile defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,6 @@ exclude = [
 # Even specifying `edition = "2021"` here will not fix this
 resolver = "2"
 
-[profile.dev]
-opt-level = 0
-lto = true
-
-[profile.release]
-opt-level = 3
-rpath = false
-lto = true
-debug-assertions = false
-overflow-checks = false
-
 [workspace.metadata.release]
 shared-version = true
 dev-version-ext = "beta.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ exclude = [
 # Even specifying `edition = "2021"` here will not fix this
 resolver = "2"
 
+[profile.release]
+lto = true
+
 [workspace.metadata.release]
 shared-version = true
 dev-version-ext = "beta.0"


### PR DESCRIPTION
Previously the build profiles for dev and release had some values being
overriden. Now the default profile values are used.

In particular the dev profile was setting `lto` to true, which caused
issues debugging tests. There was no previous motivation for the
overrides, they were copied from an earlier implementation.