### PR TITLE
Add method to get SignatureData from Quote3

### DIFF
--- a/dcap/types/src/lib.rs
+++ b/dcap/types/src/lib.rs
@@ -14,7 +14,7 @@ mod request_policy;
 
 pub use crate::{
     error::QlError,
-    quote3::{Error as Quote3Error, Quote3},
+    quote3::{CertificationData, Error as Quote3Error, Quote3, SignatureData},
     quoting_enclave::ReportInfo,
     request_policy::RequestPolicy,
 };


### PR DESCRIPTION
Add new method `Quote3::signature_data()`, which returns the signature
data for the quote