### PR TITLE
Quote the GH token in add-to-project action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
           project-url: https://github.com/orgs/mobilecoinfoundation/projects/5
 
   size-label:
@@ -42,4 +42,3 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true


### PR DESCRIPTION
- Put quotes around the ADD_TO_PROJECT_PAT token.

### Motivation

Some GHA runs appear to be failing for a lack of github-token, even though it's in the proper place. This is an experiment to see if quoting it fixes it.

