### PR TITLE
Quote the add-to-project token for issues

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -21,5 +21,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
           project-url: https://github.com/orgs/mobilecoinfoundation/projects/5


### PR DESCRIPTION
- Add quotes around the token used to add issues to projects.

### Motivation

We do this in other places, on the assumption that this fails without it.

