### PR TITLE
Allow beta clippy/docs warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,16 +65,24 @@ jobs:
     needs:
       - "rustfmt"
       - "markdown-lint"
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+    # Prevent beta warnings from causing CI failure
+    continue-on-error: ${{ matrix.rust == 'beta' }}
     steps:
       - uses: actions/checkout@v3
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
           version: 1.15.100.3-jammy1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ matrix.rust }}
           components: clippy
       - uses: r7kamura/rust-problem-matchers@v1
-      - run: cargo clippy --all --all-features --locked -- -D warnings
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features --locked -- -D warnings
 
   build:
     runs-on: ubuntu-22.04
@@ -140,6 +148,8 @@ jobs:
         rust:
           - stable
           - beta
+    # Prevent beta warnings from causing CI failure
+    continue-on-error: ${{ matrix.rust == 'beta' }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
- Run clippy against both beta and stable
- Allow doc and clippy beta to fail

### Motivation

We want to get advance notice when the next version of clippy is going to break our CI randomly, but we don't necessarily want to enforce that on PRs that are in-flight when the beta clippy is released.

