### PR TITLE
chore(deps): Bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}


### PR DESCRIPTION
- Bump actions/checkout@v2 used in ci.yaml:deny job to v3.

### Motivation

This is currently creating a deprecation warning.

