### PR TITLE
Fix beta clippy warning in core-build

### DIFF
--- a/core/build/src/lib.rs
+++ b/core/build/src/lib.rs
@@ -73,7 +73,7 @@ pub fn sgx_builder() -> Builder {
         .ctypes_prefix("core::ffi")
         .allowlist_recursively(false)
         .clang_args(env_c_flags())
-        .clang_arg(&format!("-I{}", include_path));
+        .clang_arg(format!("-I{}", include_path));
 
     cargo_emit::rerun_if_changed!(include_path);
 


### PR DESCRIPTION
- Don't `&format!()`

### Motivation

This is a change in the next release of clippy which will break CI in the future.

