### PR TITLE
Convert `CertificationData` into an enum

### DIFF
--- a/dcap/types/src/error.rs
+++ b/dcap/types/src/error.rs
@@ -20,6 +20,8 @@ pub enum Quote3Error {
     Version(u16),
     /// Failure to convert from bytes to ECDSA types
     Ecdsa,
+    /// Invalid certification data type: {0}, should be 1 - 7
+    CertificationDataType(u16),
 }
 
 impl Quote3Error {

--- a/dcap/types/src/quote3.rs
+++ b/dcap/types/src/quote3.rs
@@ -508,7 +508,7 @@ mod test {
         let signature_data = quote.signature_data();
 
         let cert_chain = match signature_data.certification_data() {
-            CertificationData::PckCertChain(cert_chain) => cert_chain,
+            CertificationData::PckCertificateChain(cert_chain) => cert_chain,
             _ => panic!("expected a PckCertChain"),
         };
 


### PR DESCRIPTION
Previously `mc-sgx-dcap-types::CertificationData` was a struct
containing opaque data. Logic was built on `CertificationData` that
assumed it would be the certificate chain variant. Now
`CertificationData` can be any of the valid variants as documented in
Table 9 of
<https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf>.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

