### PR TITLE
Mark vendored files for GitHub linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ Cargo.lock merge=theirs
 **/*.bin binary
 **/*.mdb binary
 **/*.pub binary
+core/build/headers/** linguist-vendored


### PR DESCRIPTION
The header files vendored down in `core/build/headers` have been marked
as vendored for
[GitHub linguist](https://github.com/github/linguist/blob/master/docs/overrides.md)

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

