### PR TITLE
Use globstar for copyright.yaml

### DIFF
--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: FantasticFiasco/action-update-license-year@v2

--- a/.github/workflows/copyright.yaml
+++ b/.github/workflows/copyright.yaml
@@ -15,8 +15,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: |
-            '*.rs'
-            '*.proto'
+            **/*.rs
+            **/*.proto
           assignees: '@mobilecoinfoundation/coredev'
           labels: "copyright"
           transform: (?<=^\/\/ Copyright \(c\) )(?<from>\d{4})?-?(\d{4})?


### PR DESCRIPTION
Previously the copyright.yaml workflow was using a quoted glob expression for the files. Now the copyright.yaml workflow uses an unquoted globstar expression.
    
The glob with single quotes caused a failure in `action-update-license-year`:
```
Found no files matching the path "'*.rs'\n'*.proto'"
```
(https://github.com/mobilecoinfoundation/sgx/actions/runs/3814949547)
    
Even with a globstar one would get:
```    
Found no files matching the path "'**/*.rs'\n'**/*.proto'"
```
(https://github.com/mobilecoinfoundation/sgx/actions/runs/3830770473)
   
Once the globstar and the quotes are dropped the action found the files, https://github.com/mobilecoinfoundation/sgx/actions/runs/3830798767.  It errored out with permissions to push the branch