### PR TITLE
Add thumbv7 and thumbv8 CI targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,7 +195,9 @@ jobs:
     strategy:
       matrix:
         target:
+          - thumbv6m-none-eabi
           - thumbv7m-none-eabi
+          - thumbv8m.main-none-eabi
           - aarch64-linux-android
           - aarch64-apple-ios
     steps:


### PR DESCRIPTION
The `build-no-alloc` job has been expanded to be built for
`thumbv7m-none-eabi` and `thumbv8.main-none-eabi`

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

