### PR TITLE
Expand `mc-sgx-tstdc` docs

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -10,5 +10,5 @@
 
   // Define glob expressions to use (only valid at root)
   "globs": ["**/*.md"],
-  "ignores": [".github/pull_request_template.md"]
+  "ignores": [".github/pull_request_template.md", "target/"]
 }

--- a/tstdc/README.md
+++ b/tstdc/README.md
@@ -7,7 +7,28 @@
 -->[![Docs Status][docs-image]][docs-link]<!--
 -->[![Dependency Status][deps-image]][deps-link]
 
-Rust wrappers around SGX synchronization primitives
+Rust wrappers around SGX synchronization primitives.
+
+The primitives exposed through this crate are low-level building blocks for
+higher-level constructs. Most people will want to use
+[mc-sgx-sync](https://docs.rs/mc-sgx-sync/latest/mc_sgx_sync/) to get
+[std::sync](https://doc.rust-lang.org/std/sync/) compatible constructs.
+
+The underlying implementation of [`Mutex`], [`RwLock`], and [`Condvar`] make
+OCALLs:
+
+- `sgx_thread_wait_untrusted_event_ocall()`
+- `sgx_thread_set_multiple_untrusted_events_ocall()`
+- `sgx_thread_set_untrusted_event_ocall()`
+- `sgx_thread_setwait_untrusted_events_ocall()`
+
+These OCALLs are provided the waiting thread(s) and a return value to fill out.
+The OCALLs can suspend and or spuriously wake up trusted threads. The
+application (untrusted) inherently has control of whether the enclave thread(s)
+will execute. The OCALLs further increase the surface area that the application
+has in controlling the execution of enclave thread(s). Using these
+synchronization primitives, the application is now capable of stopping enclave
+thread(s) consistently at the synchronization points.
 
 [chat-image]: https://img.shields.io/discord/844353360348971068?style=flat-square
 [chat-link]: https://mobilecoin.chat

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -79,7 +79,7 @@ pub trait ResultFrom<ST>: TryFrom<ST> {
 /// they should attach [`ResultFrom`] to the intended error wrapper associated
 /// with it, and they will get this for free.
 pub trait ResultInto<T: TryFrom<Self>>: Sized {
-    /// Flips the result of T::TryFrom<Self>.
+    /// Flips the result of `T::TryFrom<Self>`.
     fn into_result(self) -> Result<<T as TryFrom<Self>>::Error, T> {
         match T::try_from(self) {
             Ok(err) => Err(err),


### PR DESCRIPTION
Add info about:
- most consumers wanting to use `mc-sgx-sync` over using `mc-sgx-tstdc`
  directly.
- OCALLs being made in the synchronization primitives

