### PR TITLE
Remove `/*.*` from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,5 @@
 /tstdc/         @nick-mobilecoin
 /urts/          @awygle
 /util/          @jcape
-/*.*            @jcape
+/*.*            @coredev
 /LICENSE        @jcape

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,4 @@
 /tstdc/         @nick-mobilecoin
 /urts/          @awygle
 /util/          @jcape
-/*.*            @coredev
 /LICENSE        @jcape


### PR DESCRIPTION
- Adjust CODEOWNERS to not require specific reviews for `/*.*`

### Motivation

In practice, this is just bottle-necking simple changes (e.g. README updates) on James' sole approval.

