### PR TITLE
Add varsha to codeowners for sdk-tools.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 /core/          @nick-mobilecoin
 /core/build/    @jcape @nick-mobilecoin
 /dcap/          @nick-mobilecoin
-/sdk-tools/     @nick-mobilecoin
+/sdk-tools/     @nick-mobilecoin @varsha888
 /tcrypto/       @nick-mobilecoin
 /test_enclave/  @nick-mobilecoin
 /trts/          @nick-mobilecoin


### PR DESCRIPTION
- Add varsha to the required reviewers for the sdk-tools directory.

### Motivation

Varsha is contributing to the sdk-tools crate, and should be one of the reviewers for it.

