### PR TITLE
ci: Add Crev action w/ status comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,73 @@ jobs:
         with:
           globs: "**/*.md"
 
+  crev:
+    runs-on: ubuntu-22.04
+    # Override errors here, eventually we'd like to start failing PRs based on this
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+      - run: cargo check
+      - name: Initialize Cargo Crev
+        run: |-
+          cargo install cargo-crev || true
+          cargo crev trust --level high --no-commit https://github.com/mobilecoinfoundation/crev-proofs
+      - name: Run Cargo Crev
+        id: cargo-crev
+        run: |
+          set +e
+
+          export MARKER=$RANDOM
+          echo "UNREVIEWED_DEPENDENCIES<<EOF${MARKER}" >> $GITHUB_OUTPUT
+
+          # GH does not like colors in crev output
+          export TERM=xterm-mono
+
+          # - Get a TSV-formatted table of dependencies without recorded reviews
+          # - Skip any "local" dependencies
+          # - Convert the table to GHF markdown
+          # - Sort descending by the "LoC" value (first column preceeds first pipe)
+          
+          cargo crev crate verify \
+              --for-id vMr-9g5KzKQLsCpkp1tc8o7AR6a0OptjOICjf7NMyHE \
+              --show-all \
+              --skip-indirect \
+              --skip-verified \
+              --skip-known-owners \
+              --trust medium \
+              --thoroughness medium \
+              --understanding medium \
+              --redundancy 2 | \
+            grep -v '^local ' | \
+            awk '{printf("| %s | %s | %s | %s | %s | %s | %s |\n", $14, $15, $2, $10, $11, $12, $13)}' | \
+            sort -t\| -n -k5 | \
+            tee /dev/stderr >> $GITHUB_OUTPUT
+          STATUS=$?
+
+          echo "EOF${MARKER}" >> $GITHUB_OUTPUT
+          
+          set -e
+          
+          exit $STATUS
+        shell: bash
+      - uses: mshick/add-pr-comment@v2
+        if: success() || failure()
+        with:
+          message: |
+            #### :heavy_check_mark: No unreviewed dependencies found
+          message-failure: |
+            #### :x: Unreviewed dependencies found
+            
+            | Crate | Version | Reviews (N/2) | LoC | Left-Pad Index | Geiger | Flags |
+            | ----- | ------- | ------------- | --- | -------------- | ------ | ----- |
+            ${{ steps.cargo-crev.outputs.UNREVIEWED_DEPENDENCIES }}
+
   deny:
     runs-on: ubuntu-22.04
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,14 +84,13 @@ jobs:
           
           set -e
           
-          exit $STATUS
+          # TODO: Once we're ready to start failing PRs for lack of dependency reviews
+          # exit $STATUS 
+          exit 0
         shell: bash
       - uses: mshick/add-pr-comment@v2
-        if: success() || failure()
         with:
           message: |
-            #### :heavy_check_mark: No unreviewed dependencies found
-          message-failure: |
             #### :x: Unreviewed dependencies found
             
             | Crate | Version | Reviews (N/2) | LoC | Left-Pad Index | Geiger | Flags |


### PR DESCRIPTION
- [x] Add a new 'crev' job
- [x] Print out a markdown table of dependencies which need reviews.
- [x] Turn the lack of reviews into a red X

### Motivation

This is the first step towards automated dependabot approval based on existing reviews. Fixes #272 

### Future Work

- Automatically merge PRs opened by dependabot which pass `crev verify`
- Require all PRs pass `crev verify`