### PR TITLE
ci: cargo deny check advisories should show red X on failure.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,23 +97,33 @@ jobs:
             | ----- | ------- | ------------- | --- | -------------- | ------ | ----- |
             ${{ steps.cargo-crev.outputs.UNREVIEWED_DEPENDENCIES }}
 
-  deny:
+  deny-advisories:
     runs-on: ubuntu-22.04
     needs:
       - "rustfmt"
       - "markdown-lint"
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
-    # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
-      with:
-        command: check ${{ matrix.checks }}
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check advisories
+
+  deny-bans-licenses-sources:
+    runs-on: ubuntu-22.04
+    needs:
+      - "rustfmt"
+      - "markdown-lint"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check bans licenses sources
 
   sort:
     runs-on: ubuntu-22.04
@@ -292,7 +302,8 @@ jobs:
     needs:
       - rustfmt
       - markdown-lint
-      - deny
+      - deny-advisories
+      - deny-bans-licenses-sources
       - sort
       - clippy
       - build

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,9 @@ targets = []
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 vulnerability = "deny"
-unmaintained = "warn"
-yanked = "warn"
+unmaintained = "deny"
+unsound = "deny"
+yanked = "deny"
 notice = "warn"
 ignore = []
 


### PR DESCRIPTION
- Unroll the deny job strategy matrix into two jobs
- Add rust-cache to each

### Motivation

Currently, the `cargo deny check advisories` check does nothing, because it's results are hidden behind the green check due to `continue-on-error`. This removes that check in favor of independent jobs.

### Future Work

- Once merged, required checks should be updated in branch protection settings.
