### PR TITLE
Make some `mc-sgx-core-types::ReportBody` members public

### DIFF
--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},
     measurement::{Measurement, MrEnclave, MrSigner},
     quote::QuoteNonce,
-    report::{Report, ReportBody, ReportData},
+    report::{ExtendedProductId, FamilyId, IsvProductId, Report, ReportBody, ReportData},
     svn::{ConfigSvn, CpuSvn, IsvSvn},
     target_info::TargetInfo,
 };


### PR DESCRIPTION
The following types have been made public:
- `ExtendedProductId`
- `IsvProductId`
- `FamilyId`

