### PR TITLE
Remove `mc_sgx_core_types::Measurement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `mc_sgx_core_types::ReportBody::mr_enclave()` now returns a `MrEnclave`
+  instead of a `Measurement`.
+- `mc_sgx_core_types::ReportBody::mr_signer()` now returns a `MrSigner`
+  instead of a `Measurement`.
+- `mc_sgx_core_types::TargetInfo::mr_enclave()` now returns a `MrEnclave`
+  instead of a `Measurement`.
+
+### Removed
+
+- `mc_sgx_core_types::Measurement` has been removed. Use `MrEnclave` or
+  `MrSigner` instead.
+
 ## [0.4.2] - 2023-02-10
 
 ### Added

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -25,7 +25,7 @@ pub use crate::{
     config_id::ConfigId,
     error::{Error, FfiError},
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},
-    measurement::{Measurement, MrEnclave, MrSigner},
+    measurement::{MrEnclave, MrSigner},
     quote::QuoteNonce,
     report::{Report, ReportBody, ReportData},
     svn::{ConfigSvn, CpuSvn, IsvSvn},

--- a/core/types/src/measurement.rs
+++ b/core/types/src/measurement.rs
@@ -29,43 +29,35 @@ impl_newtype_for_bytestruct! {
     MrSigner, sgx_measurement_t, SGX_HASH_SIZE, m;
 }
 
-/// An enumeration of measurement options, mainly useful for describing
-/// enclave-vs-author attestation policy.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum Measurement {
-    /// A MRENCLAVE measurement
-    MrEnclave(MrEnclave),
-    /// A MRSIGNER measurement
-    MrSigner(MrSigner),
-}
-
-impl From<MrEnclave> for Measurement {
-    fn from(mr_enclave: MrEnclave) -> Self {
-        Measurement::MrEnclave(mr_enclave)
-    }
-}
-
-impl From<MrSigner> for Measurement {
-    fn from(mr_signer: MrSigner) -> Self {
-        Measurement::MrSigner(mr_signer)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
-    fn from_mr_enclave() {
-        let mr_enclave = MrEnclave::from([5u8; MrEnclave::SIZE]);
-        let measurement: Measurement = mr_enclave.into();
-        assert_eq!(measurement, Measurement::MrEnclave(mr_enclave));
+    fn from_sgx_mr_enclave() {
+        let sgx_mr_enclave = sgx_measurement_t { m: [5u8; 32] };
+        let mr_enclave: MrEnclave = sgx_mr_enclave.into();
+        assert_eq!(mr_enclave.0, sgx_mr_enclave);
     }
 
     #[test]
-    fn from_mr_signer() {
-        let mr_signer = MrSigner::from([8u8; MrSigner::SIZE]);
-        let measurement: Measurement = mr_signer.into();
-        assert_eq!(measurement, Measurement::MrSigner(mr_signer));
+    fn sgx_mr_enclave_from_mr_enclave() {
+        let mr_enclave = MrEnclave::default();
+        let sgx_mr_enclave: sgx_measurement_t = mr_enclave.into();
+        assert_eq!(sgx_mr_enclave.m, [0u8; 32]);
+    }
+
+    #[test]
+    fn from_sgx_mr_signer() {
+        let sgx_mr_signer = sgx_measurement_t { m: [9u8; 32] };
+        let mr_signer: MrSigner = sgx_mr_signer.into();
+        assert_eq!(mr_signer.0, sgx_mr_signer);
+    }
+
+    #[test]
+    fn sgx_mr_signer_from_mr_signer() {
+        let mr_signer = MrSigner::default();
+        let sgx_mr_signer: sgx_measurement_t = mr_signer.into();
+        assert_eq!(sgx_mr_signer.m, [0u8; 32]);
     }
 }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     config_id::ConfigId, impl_newtype_for_bytestruct, key_request::KeyId, new_type_accessors_impls,
-    Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, Measurement, MiscellaneousSelect, MrEnclave,
-    MrSigner,
+    Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner,
 };
 use mc_sgx_core_sys_types::{
     sgx_isvext_prod_id_t, sgx_isvfamily_id_t, sgx_mac_t, sgx_prod_id_t, sgx_report_body_t,
@@ -88,13 +87,13 @@ impl ReportBody {
     }
 
     /// The MRENCLAVE measurement
-    pub fn mr_enclave(&self) -> Measurement {
-        Measurement::MrEnclave(self.0.mr_enclave.into())
+    pub fn mr_enclave(&self) -> MrEnclave {
+        self.0.mr_enclave.into()
     }
 
     /// The MRSIGNER measurement
-    pub fn mr_signer(&self) -> Measurement {
-        Measurement::MrSigner(self.0.mr_signer.into())
+    pub fn mr_signer(&self) -> MrSigner {
+        self.0.mr_signer.into()
     }
 
     /// The Config ID
@@ -308,11 +307,8 @@ mod test {
         assert_eq!(body.miscellaneous_select(), MiscellaneousSelect::default());
         assert_eq!(body.isv_extended_product_id(), ExtendedProductId::default());
         assert_eq!(body.attributes(), Attributes::default());
-        assert_eq!(
-            body.mr_enclave(),
-            Measurement::MrEnclave(MrEnclave::default())
-        );
-        assert_eq!(body.mr_signer(), Measurement::MrSigner(MrSigner::default()));
+        assert_eq!(body.mr_enclave(), MrEnclave::default());
+        assert_eq!(body.mr_signer(), MrSigner::default());
         assert_eq!(body.config_id(), ConfigId::default());
         assert_eq!(body.isv_product_id(), IsvProductId::default());
         assert_eq!(body.isv_svn(), IsvSvn::default());
@@ -338,15 +334,9 @@ mod test {
                 .set_flags(5)
                 .set_extended_features_mask(6)
         );
-        assert_eq!(
-            body.mr_enclave(),
-            Measurement::MrEnclave(MrEnclave::from([7u8; SGX_HASH_SIZE]))
-        );
+        assert_eq!(body.mr_enclave(), MrEnclave::from([7u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved2, [8u8; SGX_REPORT_BODY_RESERVED2_BYTES]);
-        assert_eq!(
-            body.mr_signer(),
-            Measurement::MrSigner(MrSigner::from([9u8; SGX_HASH_SIZE]))
-        );
+        assert_eq!(body.mr_signer(), MrSigner::from([9u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved3, [10u8; SGX_REPORT_BODY_RESERVED3_BYTES]);
         assert_eq!(body.config_id(), ConfigId::from([11u8; SGX_CONFIGID_SIZE]));
         assert_eq!(body.isv_product_id(), IsvProductId(12));
@@ -391,15 +381,9 @@ mod test {
                 .set_flags(52)
                 .set_extended_features_mask(62)
         );
-        assert_eq!(
-            body.mr_enclave(),
-            Measurement::MrEnclave(MrEnclave::from([72u8; SGX_HASH_SIZE]))
-        );
+        assert_eq!(body.mr_enclave(), MrEnclave::from([72u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved2, [82u8; SGX_REPORT_BODY_RESERVED2_BYTES]);
-        assert_eq!(
-            body.mr_signer(),
-            Measurement::MrSigner(MrSigner::from([92u8; SGX_HASH_SIZE]))
-        );
+        assert_eq!(body.mr_signer(), MrSigner::from([92u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved3, [102u8; SGX_REPORT_BODY_RESERVED3_BYTES]);
         assert_eq!(body.config_id(), ConfigId::from([112u8; SGX_CONFIGID_SIZE]));
         assert_eq!(body.isv_product_id(), IsvProductId(122));

--- a/core/types/src/target_info.rs
+++ b/core/types/src/target_info.rs
@@ -2,8 +2,8 @@
 //! SGX TargetInfo
 
 use crate::{
-    config_id::ConfigId, new_type_accessors_impls, Attributes, ConfigSvn, Measurement,
-    MiscellaneousSelect,
+    config_id::ConfigId, new_type_accessors_impls, Attributes, ConfigSvn, MiscellaneousSelect,
+    MrEnclave,
 };
 use mc_sgx_core_sys_types::sgx_target_info_t;
 
@@ -14,8 +14,8 @@ pub struct TargetInfo(sgx_target_info_t);
 
 impl TargetInfo {
     /// The MRENCLAVE measurement
-    pub fn mr_enclave(&self) -> Measurement {
-        Measurement::MrEnclave(self.0.mr_enclave.into())
+    pub fn mr_enclave(&self) -> MrEnclave {
+        self.0.mr_enclave.into()
     }
 
     /// The attributes
@@ -46,7 +46,6 @@ new_type_accessors_impls! {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::MrEnclave;
     use mc_sgx_core_sys_types::{
         SGX_CONFIGID_SIZE, SGX_HASH_SIZE, SGX_TARGET_INFO_RESERVED1_BYTES,
         SGX_TARGET_INFO_RESERVED2_BYTES, SGX_TARGET_INFO_RESERVED3_BYTES,
@@ -55,10 +54,7 @@ mod test {
     #[test]
     fn default_target_info() {
         let info = TargetInfo::default();
-        assert_eq!(
-            info.mr_enclave(),
-            Measurement::MrEnclave(MrEnclave::default())
-        );
+        assert_eq!(info.mr_enclave(), MrEnclave::default());
         assert_eq!(info.attributes(), Attributes::default());
         assert_eq!(info.config_svn(), ConfigSvn::default());
         assert_eq!(info.miscellaneous_select(), MiscellaneousSelect::default());
@@ -83,10 +79,7 @@ mod test {
 
         let info: TargetInfo = info.into();
 
-        assert_eq!(
-            info.mr_enclave(),
-            Measurement::MrEnclave(MrEnclave::from([1u8; SGX_HASH_SIZE]))
-        );
+        assert_eq!(info.mr_enclave(), MrEnclave::from([1u8; SGX_HASH_SIZE]));
         assert_eq!(
             info.attributes(),
             Attributes::default()


### PR DESCRIPTION
`mc_sgx_core_types::Measurement` has been removed. Use `MrEnclave` or
`MrSigner` instead.

`mc_sgx_core_types::ReportBody::mr_enclave()`,
`mc_sgx_core_types::ReportBody::mr_signer()`, and
`mc_sgx_core_types::TargetInfo::mr_enclave()` have been updated to
return the appropriate `MrEnclave` or `MrSigner` types.
