### PR TITLE
Implement `Display` for `CpuSvn`

### DIFF
--- a/core/types/src/macros.rs
+++ b/core/types/src/macros.rs
@@ -101,7 +101,7 @@ macro_rules! impl_newtype_for_bytestruct {
             type Error = $crate::FfiError;
 
             fn try_from(src: &[u8]) -> ::core::result::Result<Self, Self::Error> {
-                if src.len() != $size {
+                if src.len() < $size {
                     return Err($crate::FfiError::InvalidInputLength);
                 }
 

--- a/core/types/src/macros.rs
+++ b/core/types/src/macros.rs
@@ -101,7 +101,7 @@ macro_rules! impl_newtype_for_bytestruct {
             type Error = $crate::FfiError;
 
             fn try_from(src: &[u8]) -> ::core::result::Result<Self, Self::Error> {
-                if src.len() < $size {
+                if src.len() != $size {
                     return Err($crate::FfiError::InvalidInputLength);
                 }
 

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -30,3 +30,21 @@ pub struct CpuSvn(sgx_cpu_svn_t);
 impl_newtype_for_bytestruct! {
     CpuSvn, sgx_cpu_svn_t, SGX_CPUSVN_SIZE, svn;
 }
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+
+    use super::*;
+    use std::format;
+
+    #[test]
+    fn cpu_svn_display() {
+        let cpu_svn = CpuSvn::from([1u8; CpuSvn::SIZE]);
+
+        let display_string = format!("{}", cpu_svn);
+        let expected_string = "0x0101_0101_0101_0101_0101_0101_0101_0101";
+
+        assert_eq!(display_string, expected_string);
+    }
+}


### PR DESCRIPTION
### Motivation
This PR implements `Display` for `CpuSvn` in order to make `attestation` repo errors more readable and useful (see https://github.com/mobilecoinfoundation/attestation/pull/54). Previously, we implemented `Display` in the `new_types!` macro and relied on the `Debug` trait. The new `Display` implementation prints out the `CpuSvn` byte array in `UpperHex` format.

### Future Work
- Continue implementing `Display` trait for `mc_sgx_core_types` 

