### PR TITLE
Implement `Display` for `mc-sgx-core-types`

### DIFF
--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -220,8 +220,8 @@ mod test {
 
     #[test]
     fn miscellaneous_select_display() {
-        let sgx_misc_select_t = 18983928;
-        let miscellaneous_select = MiscellaneousSelect::from(sgx_misc_select_t);
+        let inner = 18983928;
+        let miscellaneous_select = MiscellaneousSelect::from(inner);
 
         let display_string = format!("{}", miscellaneous_select);
         let expected_string = format!("0x0121_ABF8");

--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -197,9 +197,7 @@ mod test {
             .set_extended_features_mask(xfrm.bits());
 
         let display_string = format!("{}", attributes);
-        let expected = format!(
-            "Flags: {flag1} | {flag2} | {flag3} Xfrm: {xfrm1} | {xfrm2}",
-        );
+        let expected = format!("Flags: {flag1} | {flag2} | {flag3} Xfrm: {xfrm1} | {xfrm2}",);
 
         assert_eq!(display_string, expected);
     }
@@ -217,9 +215,8 @@ mod test {
         let attributes = Attributes::default().set_flags(flags.bits());
 
         let display_string = format!("{}", attributes);
-        let expected = format!(
-            "Flags: {flag1} | {flag2} | {flag3} | {flag4} | {flag5} | {flag6} Xfrm: ",
-        );
+        let expected =
+            format!("Flags: {flag1} | {flag2} | {flag3} | {flag4} | {flag5} | {flag6} Xfrm: ",);
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -44,8 +44,16 @@ impl Attributes {
 
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Flags: {}", Flags::from_bits(self.0.flags).unwrap())?;
-        write!(f, " Xfrm: {}", Xfrm::from_bits(self.0.xfrm).unwrap())
+        match Flags::from_bits(self.0.flags) {
+            Some(flags) =>   write!(f, "Flags: {}", flags)?,
+            None => write!(f, "Flags: ")?,
+        }
+        match Xfrm::from_bits(self.0.xfrm) {
+            Some(xfrm) =>  write!(f, "Xfrm: {}", xfrm)?,
+            None => write!(f, "Xfrm: ")?
+        }
+
+        Ok(())
     }
 }
 

--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -45,12 +45,12 @@ impl Attributes {
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match Flags::from_bits(self.0.flags) {
-            Some(flags) =>   write!(f, "Flags: {}", flags)?,
+            Some(flags) => write!(f, "Flags: {}", flags)?,
             None => write!(f, "Flags: ")?,
         }
         match Xfrm::from_bits(self.0.xfrm) {
-            Some(xfrm) =>  write!(f, "Xfrm: {}", xfrm)?,
-            None => write!(f, "Xfrm: ")?
+            Some(xfrm) => write!(f, "Xfrm: {}", xfrm)?,
+            None => write!(f, "Xfrm: ")?,
         }
 
         Ok(())
@@ -153,7 +153,7 @@ mod test {
     extern crate std;
 
     use super::*;
-    use std::format;
+    use std::{format, string::ToString};
     use yare::parameterized;
 
     #[test]
@@ -232,7 +232,7 @@ mod test {
         let miscellaneous_select = MiscellaneousSelect::from(inner);
 
         let display_string = format!("{}", miscellaneous_select);
-        let expected_string = format!("0x0121_ABF8");
+        let expected_string = "0x0121_ABF8".to_string();
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -45,12 +45,24 @@ impl Attributes {
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match Flags::from_bits(self.0.flags) {
-            Some(flags) => write!(f, "Flags: {}", flags)?,
-            None => write!(f, "Flags: ")?,
+            Some(flags) => {
+                if flags.is_empty() {
+                    write!(f, "Flags: (none)")?
+                } else {
+                    write!(f, "Flags: {}", flags)?
+                }
+            }
+            None => write!(f, "Flags: (none)")?,
         }
         match Xfrm::from_bits(self.0.xfrm) {
-            Some(xfrm) => write!(f, " Xfrm: {}", xfrm)?,
-            None => write!(f, " Xfrm: ")?,
+            Some(xfrm) => {
+                if xfrm.is_empty() {
+                    write!(f, " Xfrm: (none)")?
+                } else {
+                    write!(f, " Xfrm: {}", xfrm)?
+                }
+            }
+            None => write!(f, " Xfrm: (none)")?,
         }
 
         Ok(())
@@ -215,8 +227,22 @@ mod test {
         let attributes = Attributes::default().set_flags(flags.bits());
 
         let display_string = format!("{}", attributes);
-        let expected =
-            format!("Flags: {flag1} | {flag2} | {flag3} | {flag4} | {flag5} | {flag6} Xfrm: ",);
+        let expected = format!(
+            "Flags: {flag1} | {flag2} | {flag3} | {flag4} | {flag5} | {flag6} Xfrm: (none)",
+        );
+
+        assert_eq!(display_string, expected);
+    }
+
+    #[test]
+    fn attributes_display_no_flags() {
+        let xfrm1 = Xfrm::LEGACY;
+        let xfrm2 = Xfrm::AVX;
+        let xfrm = xfrm1 | xfrm2;
+        let attributes = Attributes::default().set_extended_features_mask(xfrm.bits());
+
+        let display_string = format!("{}", attributes);
+        let expected = format!("Flags: (none) Xfrm: {xfrm1} | {xfrm2}",);
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/attributes.rs
+++ b/core/types/src/attributes.rs
@@ -49,8 +49,8 @@ impl Display for Attributes {
             None => write!(f, "Flags: ")?,
         }
         match Xfrm::from_bits(self.0.xfrm) {
-            Some(xfrm) => write!(f, "Xfrm: {}", xfrm)?,
-            None => write!(f, "Xfrm: ")?,
+            Some(xfrm) => write!(f, " Xfrm: {}", xfrm)?,
+            None => write!(f, " Xfrm: ")?,
         }
 
         Ok(())
@@ -153,7 +153,7 @@ mod test {
     extern crate std;
 
     use super::*;
-    use std::{format, string::ToString};
+    use std::format;
     use yare::parameterized;
 
     #[test]
@@ -198,8 +198,7 @@ mod test {
 
         let display_string = format!("{}", attributes);
         let expected = format!(
-            "Flags: {} | {} | {} Xfrm: {} | {}",
-            flag1, flag2, flag3, xfrm1, xfrm2
+            "Flags: {flag1} | {flag2} | {flag3} Xfrm: {xfrm1} | {xfrm2}",
         );
 
         assert_eq!(display_string, expected);
@@ -219,8 +218,7 @@ mod test {
 
         let display_string = format!("{}", attributes);
         let expected = format!(
-            "Flags: {} | {} | {} | {} | {} | {} Xfrm: ",
-            flag1, flag2, flag3, flag4, flag5, flag6,
+            "Flags: {flag1} | {flag2} | {flag3} | {flag4} | {flag5} | {flag6} Xfrm: ",
         );
 
         assert_eq!(display_string, expected);
@@ -231,8 +229,8 @@ mod test {
         let inner = 18983928;
         let miscellaneous_select = MiscellaneousSelect::from(inner);
 
-        let display_string = format!("{}", miscellaneous_select);
-        let expected_string = "0x0121_ABF8".to_string();
+        let display_string = format!("{miscellaneous_select}");
+        let expected_string = "0x0121_ABF8";
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/config_id.rs
+++ b/core/types/src/config_id.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX Config ID
 
-use crate::impl_newtype;
+use crate::impl_newtype_no_display;
+use core::fmt::{Display, Formatter};
 use mc_sgx_core_sys_types::{sgx_config_id_t, SGX_CONFIGID_SIZE};
 
 /// Config ID
@@ -9,13 +10,38 @@ use mc_sgx_core_sys_types::{sgx_config_id_t, SGX_CONFIGID_SIZE};
 #[repr(transparent)]
 pub struct ConfigId(sgx_config_id_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     ConfigId, sgx_config_id_t;
+}
+
+impl Display for ConfigId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ConfigId: ")?;
+        mc_sgx_util::fmt_hex(&self.0, f)
+    }
 }
 
 // Pure array type larger than 32 so must implement default at the newtype level
 impl Default for ConfigId {
     fn default() -> Self {
         Self::from([0; SGX_CONFIGID_SIZE])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use crate::ConfigId;
+    use std::format;
+
+    #[test]
+    fn display_config_id() {
+        let sgx_config_id_t = [34u8; 64];
+        let config_id = ConfigId::from(sgx_config_id_t);
+
+        let display_string = format!("{}", config_id);
+        let expected = "ConfigId: 2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222";
+
+        assert_eq!(display_string, expected);
     }
 }

--- a/core/types/src/config_id.rs
+++ b/core/types/src/config_id.rs
@@ -39,7 +39,7 @@ mod tests {
         let inner = [34u8; 64];
         let config_id = ConfigId::from(inner);
 
-        let display_string = format!("{}", config_id);
+        let display_string = format!("{config_id}");
         let expected = "0x2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222";
 
         assert_eq!(display_string, expected);

--- a/core/types/src/config_id.rs
+++ b/core/types/src/config_id.rs
@@ -16,7 +16,6 @@ impl_newtype_no_display! {
 
 impl Display for ConfigId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ConfigId: ")?;
         mc_sgx_util::fmt_hex(&self.0, f)
     }
 }
@@ -31,7 +30,8 @@ impl Default for ConfigId {
 #[cfg(test)]
 mod tests {
     extern crate std;
-    use crate::ConfigId;
+
+    use super::*;
     use std::format;
 
     #[test]
@@ -40,7 +40,7 @@ mod tests {
         let config_id = ConfigId::from(sgx_config_id_t);
 
         let display_string = format!("{}", config_id);
-        let expected = "ConfigId: 2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222";
+        let expected = "0x2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/config_id.rs
+++ b/core/types/src/config_id.rs
@@ -36,8 +36,8 @@ mod tests {
 
     #[test]
     fn display_config_id() {
-        let sgx_config_id_t = [34u8; 64];
-        let config_id = ConfigId::from(sgx_config_id_t);
+        let inner = [34u8; 64];
+        let config_id = ConfigId::from(inner);
 
         let display_string = format!("{}", config_id);
         let expected = "0x2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222_2222";

--- a/core/types/src/measurement.rs
+++ b/core/types/src/measurement.rs
@@ -68,7 +68,7 @@ mod test {
     fn display_mr_enclave() {
         let mr_enclave = MrEnclave::from([1u8; MrEnclave::SIZE]);
 
-        let display_string = format!("{}", mr_enclave);
+        let display_string = format!("{mr_enclave}");
         let expected_string =
             "0x0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
 
@@ -79,7 +79,7 @@ mod test {
     fn display_mr_signer() {
         let mr_signer = MrSigner::from([1u8; MrSigner::SIZE]);
 
-        let display_string = format!("{}", mr_signer);
+        let display_string = format!("{mr_signer}");
         let expected_string =
             "0x0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
 

--- a/core/types/src/measurement.rs
+++ b/core/types/src/measurement.rs
@@ -4,7 +4,8 @@
 //!
 //! Different types are used for MrSigner and MrEnclave to prevent misuse.
 
-use crate::impl_newtype_for_bytestruct;
+use crate::impl_newtype_for_bytestruct_no_display;
+use core::fmt::{Display, Formatter};
 use mc_sgx_core_sys_types::{sgx_measurement_t, SGX_HASH_SIZE};
 
 /// An opaque type for MRENCLAVE values
@@ -24,14 +25,29 @@ pub struct MrEnclave(sgx_measurement_t);
 #[repr(transparent)]
 pub struct MrSigner(sgx_measurement_t);
 
-impl_newtype_for_bytestruct! {
+impl_newtype_for_bytestruct_no_display! {
     MrEnclave, sgx_measurement_t, SGX_HASH_SIZE, m;
     MrSigner, sgx_measurement_t, SGX_HASH_SIZE, m;
 }
 
+impl Display for MrEnclave {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MrEnclave: {:X}", self)
+    }
+}
+
+impl Display for MrSigner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MrSigner: {:X}", self)
+    }
+}
+
 #[cfg(test)]
 mod test {
+    extern crate std;
+
     use super::*;
+    use std::format;
 
     #[test]
     fn from_sgx_mr_enclave() {
@@ -59,5 +75,25 @@ mod test {
         let mr_signer = MrSigner::default();
         let sgx_mr_signer: sgx_measurement_t = mr_signer.into();
         assert_eq!(sgx_mr_signer.m, [0u8; 32]);
+    }
+
+    #[test]
+    fn display_mr_enclave() {
+        let mr_enclave = MrEnclave::from([1u8; MrEnclave::SIZE]);
+
+        let display_string = format!("{}", mr_enclave);
+        let expected_string = "MrEnclave: 0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
+
+        assert_eq!(display_string, expected_string);
+    }
+
+    #[test]
+    fn display_mr_signer() {
+        let mr_signer = MrSigner::from([1u8; MrSigner::SIZE]);
+
+        let display_string = format!("{}", mr_signer);
+        let expected_string = "MrSigner: 0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
+
+        assert_eq!(display_string, expected_string);
     }
 }

--- a/core/types/src/measurement.rs
+++ b/core/types/src/measurement.rs
@@ -4,8 +4,7 @@
 //!
 //! Different types are used for MrSigner and MrEnclave to prevent misuse.
 
-use crate::impl_newtype_for_bytestruct_no_display;
-use core::fmt::{Display, Formatter};
+use crate::impl_newtype_for_bytestruct;
 use mc_sgx_core_sys_types::{sgx_measurement_t, SGX_HASH_SIZE};
 
 /// An opaque type for MRENCLAVE values
@@ -25,21 +24,9 @@ pub struct MrEnclave(sgx_measurement_t);
 #[repr(transparent)]
 pub struct MrSigner(sgx_measurement_t);
 
-impl_newtype_for_bytestruct_no_display! {
+impl_newtype_for_bytestruct! {
     MrEnclave, sgx_measurement_t, SGX_HASH_SIZE, m;
     MrSigner, sgx_measurement_t, SGX_HASH_SIZE, m;
-}
-
-impl Display for MrEnclave {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "MrEnclave: {:X}", self)
-    }
-}
-
-impl Display for MrSigner {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "MrSigner: {:X}", self)
-    }
 }
 
 #[cfg(test)]
@@ -82,7 +69,8 @@ mod test {
         let mr_enclave = MrEnclave::from([1u8; MrEnclave::SIZE]);
 
         let display_string = format!("{}", mr_enclave);
-        let expected_string = "MrEnclave: 0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
+        let expected_string =
+            "0x0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
 
         assert_eq!(display_string, expected_string);
     }
@@ -92,7 +80,8 @@ mod test {
         let mr_signer = MrSigner::from([1u8; MrSigner::SIZE]);
 
         let display_string = format!("{}", mr_signer);
-        let expected_string = "MrSigner: 0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
+        let expected_string =
+            "0x0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101_0101";
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -71,7 +71,6 @@ impl_newtype_no_display! {
 
 impl Display for FamilyId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "FamilyId: ")?;
         mc_sgx_util::fmt_hex(&self.0, f)
     }
 }
@@ -559,7 +558,7 @@ mod test {
         let family_id = FamilyId::from(sgx_isvfamily_id_t);
 
         let display_string = format!("{}", family_id);
-        let expected = "FamilyId: 0505_0505_0505_0505_0505_0505_0505_0505";
+        let expected = "0x0505_0505_0505_0505_0505_0505_0505_0505";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -2,9 +2,9 @@
 //! SGX Report
 
 use crate::{
-    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct_no_display,
-    impl_newtype_no_display, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn,
-    MiscellaneousSelect, MrEnclave, MrSigner,
+    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display,
+    key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect,
+    MrEnclave, MrSigner,
 };
 use core::fmt::{Display, Formatter};
 use core::ops::BitAnd;
@@ -32,14 +32,8 @@ impl_newtype! {
 #[repr(transparent)]
 pub struct ReportData(sgx_report_data_t);
 
-impl_newtype_for_bytestruct_no_display! {
+impl_newtype_for_bytestruct! {
     ReportData, sgx_report_data_t, SGX_REPORT_DATA_SIZE, d;
-}
-
-impl Display for ReportData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ReportData: {:X}", self)
-    }
 }
 
 /// There are times when only part of [`ReportData`] is of interest. [`BitAnd`]
@@ -575,7 +569,7 @@ mod test {
         let report_data = ReportData::from(sgx_report_data_t);
 
         let display_string = format!("{}", report_data);
-        let expected = "ReportData: 0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202";
+        let expected = "0x0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -536,7 +536,7 @@ mod test {
         let inner = [42u8; SGX_ISVEXT_PROD_ID_SIZE];
         let extended_product_id = ExtendedProductId::from(inner);
 
-        let display_string = format!("{}", extended_product_id);
+        let display_string = format!("{extended_product_id}");
         let expected = format!("{}", u128::from_be_bytes(inner));
 
         assert_eq!(display_string, expected);
@@ -547,8 +547,8 @@ mod test {
         let inner = 60000u16;
         let isv_product_id = IsvProductId::from(inner);
 
-        let display_string = format!("{}", isv_product_id);
-        let expected = format!("{}", inner);
+        let display_string = format!("{isv_product_id}");
+        let expected = format!("{inner}");
 
         assert_eq!(display_string, expected);
     }
@@ -558,7 +558,7 @@ mod test {
         let inner = [5u8; SGX_ISV_FAMILY_ID_SIZE];
         let family_id = FamilyId::from(inner);
 
-        let display_string = format!("{}", family_id);
+        let display_string = format!("{family_id}");
         let expected = "0x0505_0505_0505_0505_0505_0505_0505_0505";
 
         assert_eq!(display_string, expected);
@@ -569,7 +569,7 @@ mod test {
         let inner = [2u8; SGX_REPORT_DATA_SIZE];
         let report_data = ReportData::from(inner);
 
-        let display_string = format!("{}", report_data);
+        let display_string = format!("{report_data}");
         let expected = "0x0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202";
 
         assert_eq!(display_string, expected);

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -89,8 +89,15 @@ impl Display for ExtendedProductId {
 #[repr(transparent)]
 pub struct IsvProductId(sgx_prod_id_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     IsvProductId, sgx_prod_id_t;
+}
+
+impl Display for IsvProductId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "IsvProductId: ")?;
+        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+    }
 }
 
 /// The main body of a report from SGX
@@ -525,6 +532,17 @@ mod test {
 
         let display_string = format!("{}", extended_product_id);
         let expected = "0x2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A";
+
+        assert_eq!(display_string, expected);
+    }
+
+    #[test]
+    fn display_isv_product_id() {
+        let sgx_prod_id_t = 60000u16;
+        let isv_product_id = IsvProductId::from(sgx_prod_id_t);
+
+        let display_string = format!("{}", isv_product_id);
+        let expected = format!("IsvProductId: {:X}", sgx_prod_id_t);
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -95,7 +95,6 @@ impl_newtype_no_display! {
 
 impl Display for IsvProductId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "IsvProductId: ")?;
         mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
     }
 }
@@ -542,7 +541,7 @@ mod test {
         let isv_product_id = IsvProductId::from(sgx_prod_id_t);
 
         let display_string = format!("{}", isv_product_id);
-        let expected = format!("IsvProductId: {:X}", sgx_prod_id_t);
+        let expected = format!("0x{:X}", sgx_prod_id_t);
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -86,7 +86,8 @@ impl_newtype_no_display! {
 
 impl Display for ExtendedProductId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        mc_sgx_util::fmt_hex(&self.0, f)
+        let inner = u128::from_be_bytes(self.0);
+        write!(f, "{}", inner)
     }
 }
 
@@ -101,7 +102,7 @@ impl_newtype_no_display! {
 
 impl Display for IsvProductId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+        write!(f, "{}", &self.0)
     }
 }
 
@@ -532,30 +533,30 @@ mod test {
 
     #[test]
     fn display_extended_product_id() {
-        let sgx_isvext_prod_id_t = [42u8; SGX_ISVEXT_PROD_ID_SIZE];
-        let extended_product_id = ExtendedProductId::from(sgx_isvext_prod_id_t);
+        let inner = [42u8; SGX_ISVEXT_PROD_ID_SIZE];
+        let extended_product_id = ExtendedProductId::from(inner);
 
         let display_string = format!("{}", extended_product_id);
-        let expected = "0x2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A";
+        let expected = format!("{}", u128::from_be_bytes(inner));
 
         assert_eq!(display_string, expected);
     }
 
     #[test]
     fn display_isv_product_id() {
-        let sgx_prod_id_t = 60000u16;
-        let isv_product_id = IsvProductId::from(sgx_prod_id_t);
+        let inner = 60000u16;
+        let isv_product_id = IsvProductId::from(inner);
 
         let display_string = format!("{}", isv_product_id);
-        let expected = format!("0x{:X}", sgx_prod_id_t);
+        let expected = format!("{}", inner);
 
         assert_eq!(display_string, expected);
     }
 
     #[test]
     fn display_family_id() {
-        let sgx_isvfamily_id_t = [5u8; SGX_ISV_FAMILY_ID_SIZE];
-        let family_id = FamilyId::from(sgx_isvfamily_id_t);
+        let inner = [5u8; SGX_ISV_FAMILY_ID_SIZE];
+        let family_id = FamilyId::from(inner);
 
         let display_string = format!("{}", family_id);
         let expected = "0x0505_0505_0505_0505_0505_0505_0505_0505";
@@ -565,8 +566,8 @@ mod test {
 
     #[test]
     fn display_report_data() {
-        let sgx_report_data_t = [2u8; SGX_REPORT_DATA_SIZE];
-        let report_data = ReportData::from(sgx_report_data_t);
+        let inner = [2u8; SGX_REPORT_DATA_SIZE];
+        let report_data = ReportData::from(inner);
 
         let display_string = format!("{}", report_data);
         let expected = "0x0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202";

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -1,11 +1,7 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX Report
 
-use crate::{
-    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display,
-    key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect,
-    MrEnclave, MrSigner,
-};
+use crate::{config_id::ConfigId, impl_newtype, impl_newtype_no_display, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner, impl_newtype_for_bytestruct_no_display};
 use core::fmt::{Display, Formatter};
 use core::ops::BitAnd;
 use mc_sgx_core_sys_types::{
@@ -32,8 +28,14 @@ impl_newtype! {
 #[repr(transparent)]
 pub struct ReportData(sgx_report_data_t);
 
-impl_newtype_for_bytestruct! {
+impl_newtype_for_bytestruct_no_display! {
     ReportData, sgx_report_data_t, SGX_REPORT_DATA_SIZE, d;
+}
+
+impl Display for ReportData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ReportData: {:X}", self)
+    }
 }
 
 /// There are times when only part of [`ReportData`] is of interest. [`BitAnd`]
@@ -559,6 +561,17 @@ mod test {
 
         let display_string = format!("{}", family_id);
         let expected = "0x0505_0505_0505_0505_0505_0505_0505_0505";
+
+        assert_eq!(display_string, expected);
+    }
+
+    #[test]
+    fn display_report_data() {
+        let sgx_report_data_t = [2u8; SGX_REPORT_DATA_SIZE];
+        let report_data = ReportData::from(sgx_report_data_t);
+
+        let display_string = format!("{}", report_data);
+        let expected = "ReportData: 0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202_0202";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -1,10 +1,8 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX Report
 
-use crate::{
-    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, key_request::KeyId, Attributes,
-    ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner,
-};
+use core::fmt::{Display, Formatter};
+use crate::{config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner, impl_newtype_no_display};
 use core::ops::BitAnd;
 use mc_sgx_core_sys_types::{
     sgx_isvext_prod_id_t, sgx_isvfamily_id_t, sgx_mac_t, sgx_prod_id_t, sgx_report_body_t,
@@ -72,8 +70,15 @@ impl_newtype! {
 #[repr(transparent)]
 pub struct ExtendedProductId(sgx_isvext_prod_id_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     ExtendedProductId, sgx_isvext_prod_id_t;
+}
+
+impl Display for ExtendedProductId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ExtendedProductId: ")?;
+        mc_sgx_util::fmt_hex(&self.0, f)
+    }
 }
 
 /// ISV Product ID
@@ -250,6 +255,7 @@ impl_newtype! {
 mod test {
     extern crate std;
 
+    use std::format;
     use super::*;
     use crate::{key_request::KeyId, MrEnclave, MrSigner};
     use core::{mem, slice};
@@ -507,5 +513,16 @@ mod test {
             &ReportData::from(left) & &ReportData::from(right),
             ReportData::from(expected)
         );
+    }
+
+    #[test]
+    fn display_extended_product_id() {
+        let sgx_isvext_prod_id_t = [42u8; SGX_ISVEXT_PROD_ID_SIZE];
+        let extended_product_id = ExtendedProductId::from(sgx_isvext_prod_id_t);
+
+        let display_string = format!("{}", extended_product_id);
+        let expected = "ExtendedProductId: 2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A";
+
+        assert_eq!(display_string, expected);
     }
 }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -80,7 +80,6 @@ impl_newtype_no_display! {
 
 impl Display for ExtendedProductId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ExtendedProductId: ")?;
         mc_sgx_util::fmt_hex(&self.0, f)
     }
 }
@@ -525,7 +524,7 @@ mod test {
         let extended_product_id = ExtendedProductId::from(sgx_isvext_prod_id_t);
 
         let display_string = format!("{}", extended_product_id);
-        let expected = "ExtendedProductId: 2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A";
+        let expected = "0x2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A_2A2A";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -65,8 +65,15 @@ impl BitAnd for ReportData {
 #[repr(transparent)]
 pub struct FamilyId(sgx_isvfamily_id_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     FamilyId, sgx_isvfamily_id_t;
+}
+
+impl Display for FamilyId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "FamilyId: ")?;
+        mc_sgx_util::fmt_hex(&self.0, f)
+    }
 }
 
 /// Extended Product ID
@@ -542,6 +549,17 @@ mod test {
 
         let display_string = format!("{}", isv_product_id);
         let expected = format!("0x{:X}", sgx_prod_id_t);
+
+        assert_eq!(display_string, expected);
+    }
+
+    #[test]
+    fn display_family_id() {
+        let sgx_isvfamily_id_t = [5u8; SGX_ISV_FAMILY_ID_SIZE];
+        let family_id = FamilyId::from(sgx_isvfamily_id_t);
+
+        let display_string = format!("{}", family_id);
+        let expected = "FamilyId: 0505_0505_0505_0505_0505_0505_0505_0505";
 
         assert_eq!(display_string, expected);
     }

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -1,7 +1,11 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX Report
 
-use crate::{config_id::ConfigId, impl_newtype, impl_newtype_no_display, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner, impl_newtype_for_bytestruct_no_display};
+use crate::{
+    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct_no_display,
+    impl_newtype_no_display, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn,
+    MiscellaneousSelect, MrEnclave, MrSigner,
+};
 use core::fmt::{Display, Formatter};
 use core::ops::BitAnd;
 use mc_sgx_core_sys_types::{

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -1,8 +1,12 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX Report
 
+use crate::{
+    config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display,
+    key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect,
+    MrEnclave, MrSigner,
+};
 use core::fmt::{Display, Formatter};
-use crate::{config_id::ConfigId, impl_newtype, impl_newtype_for_bytestruct, key_request::KeyId, Attributes, ConfigSvn, CpuSvn, FfiError, IsvSvn, MiscellaneousSelect, MrEnclave, MrSigner, impl_newtype_no_display};
 use core::ops::BitAnd;
 use mc_sgx_core_sys_types::{
     sgx_isvext_prod_id_t, sgx_isvfamily_id_t, sgx_mac_t, sgx_prod_id_t, sgx_report_body_t,
@@ -255,11 +259,11 @@ impl_newtype! {
 mod test {
     extern crate std;
 
-    use std::format;
     use super::*;
     use crate::{key_request::KeyId, MrEnclave, MrSigner};
     use core::{mem, slice};
     use mc_sgx_core_sys_types::{SGX_KEYID_SIZE, SGX_MAC_SIZE};
+    use std::format;
     use yare::parameterized;
 
     fn report_body_1() -> sgx_report_body_t {

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX core SVN (Security Version Numbers)
 
+use core::fmt::{Display, Formatter};
 use crate::{impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display};
 use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_CPUSVN_SIZE};
 
@@ -20,6 +21,12 @@ pub struct IsvSvn(sgx_isv_svn_t);
 
 impl_newtype_no_display! {
     IsvSvn, sgx_isv_svn_t;
+}
+
+impl Display for IsvSvn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+    }
 }
 
 /// CPU security version number (SVN)

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX core SVN (Security Version Numbers)
 
-use crate::{impl_newtype, impl_newtype_for_bytestruct};
+use crate::{impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display};
 use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_CPUSVN_SIZE};
 
 /// Config security version number (SVN)
@@ -18,7 +18,7 @@ impl_newtype! {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct IsvSvn(sgx_isv_svn_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     IsvSvn, sgx_isv_svn_t;
 }
 
@@ -44,6 +44,17 @@ mod test {
 
         let display_string = format!("{}", cpu_svn);
         let expected_string = "0x0101_0101_0101_0101_0101_0101_0101_0101";
+
+        assert_eq!(display_string, expected_string);
+    }
+
+    #[test]
+    fn isv_svn_display() {
+        let sgx_isv_svn_t = 3459;
+        let isv_svn = IsvSvn::from(sgx_isv_svn_t);
+
+        let display_string = format!("{}", isv_svn);
+        let expected_string = "0x0D83";
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX core SVN (Security Version Numbers)
 
-use crate::{impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display};
+use crate::{impl_newtype_for_bytestruct, impl_newtype_no_display};
 use core::fmt::{Display, Formatter};
 use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_CPUSVN_SIZE};
 
@@ -12,6 +12,12 @@ pub struct ConfigSvn(sgx_config_svn_t);
 
 impl_newtype_no_display! {
     ConfigSvn, sgx_config_svn_t;
+}
+
+impl Display for ConfigSvn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 /// Independent software vendor (ISV) security version number (SVN)
@@ -25,7 +31,7 @@ impl_newtype_no_display! {
 
 impl Display for IsvSvn {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+        write!(f, "{}", self.0)
     }
 }
 
@@ -33,12 +39,6 @@ impl Display for IsvSvn {
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct CpuSvn(sgx_cpu_svn_t);
-
-impl Display for ConfigSvn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
-    }
-}
 
 impl_newtype_for_bytestruct! {
     CpuSvn, sgx_cpu_svn_t, SGX_CPUSVN_SIZE, svn;
@@ -63,22 +63,22 @@ mod test {
 
     #[test]
     fn isv_svn_display() {
-        let sgx_isv_svn_t = 3459;
-        let isv_svn = IsvSvn::from(sgx_isv_svn_t);
+        let inner = 3459;
+        let isv_svn = IsvSvn::from(inner);
 
         let display_string = format!("{}", isv_svn);
-        let expected_string = "0x0D83";
+        let expected_string = format!("{}", inner);
 
         assert_eq!(display_string, expected_string);
     }
 
     #[test]
     fn config_svn_display() {
-        let sgx_config_svn_t = 3298;
-        let config_svn = ConfigSvn::from(sgx_config_svn_t);
+        let inner = 3298;
+        let config_svn = ConfigSvn::from(inner);
 
         let display_string = format!("{}", config_svn);
-        let expected_string = "0x0CE2";
+        let expected_string = format!("{}", inner);
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -14,13 +14,6 @@ impl_newtype_no_display! {
     ConfigSvn, sgx_config_svn_t;
 }
 
-impl Display for ConfigSvn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ConfigSvn: ")?;
-        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
-    }
-}
-
 /// Independent software vendor (ISV) security version number (SVN)
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
@@ -79,7 +72,7 @@ mod test {
         let config_svn = ConfigSvn::from(sgx_config_svn_t);
 
         let display_string = format!("{}", config_svn);
-        let expected_string = "ConfigSvn: 0CE2";
+        let expected_string = "0x0CE2";
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -10,8 +10,15 @@ use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
 pub struct ConfigSvn(sgx_config_svn_t);
 
-impl_newtype! {
+impl_newtype_no_display! {
     ConfigSvn, sgx_config_svn_t;
+}
+
+impl Display for ConfigSvn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ConfigSvn: ")?;
+        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+    }
 }
 
 /// Independent software vendor (ISV) security version number (SVN)
@@ -62,6 +69,17 @@ mod test {
 
         let display_string = format!("{}", isv_svn);
         let expected_string = "0x0D83";
+
+        assert_eq!(display_string, expected_string);
+    }
+
+    #[test]
+    fn config_svn_display() {
+        let sgx_config_svn_t = 3298;
+        let config_svn = ConfigSvn::from(sgx_config_svn_t);
+
+        let display_string = format!("{}", config_svn);
+        let expected_string = "ConfigSvn: 0CE2";
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -55,7 +55,7 @@ mod test {
     fn cpu_svn_display() {
         let cpu_svn = CpuSvn::from([1u8; CpuSvn::SIZE]);
 
-        let display_string = format!("{}", cpu_svn);
+        let display_string = format!("{cpu_svn}");
         let expected_string = "0x0101_0101_0101_0101_0101_0101_0101_0101";
 
         assert_eq!(display_string, expected_string);
@@ -66,8 +66,8 @@ mod test {
         let inner = 3459;
         let isv_svn = IsvSvn::from(inner);
 
-        let display_string = format!("{}", isv_svn);
-        let expected_string = format!("{}", inner);
+        let display_string = format!("{isv_svn}");
+        let expected_string = format!("{inner}");
 
         assert_eq!(display_string, expected_string);
     }
@@ -77,8 +77,8 @@ mod test {
         let inner = 3298;
         let config_svn = ConfigSvn::from(inner);
 
-        let display_string = format!("{}", config_svn);
-        let expected_string = format!("{}", inner);
+        let display_string = format!("{config_svn}");
+        let expected_string = format!("{inner}");
 
         assert_eq!(display_string, expected_string);
     }

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 //! SGX core SVN (Security Version Numbers)
 
-use core::fmt::{Display, Formatter};
 use crate::{impl_newtype, impl_newtype_for_bytestruct, impl_newtype_no_display};
+use core::fmt::{Display, Formatter};
 use mc_sgx_core_sys_types::{sgx_config_svn_t, sgx_cpu_svn_t, sgx_isv_svn_t, SGX_CPUSVN_SIZE};
 
 /// Config security version number (SVN)

--- a/core/types/src/svn.rs
+++ b/core/types/src/svn.rs
@@ -34,6 +34,12 @@ impl Display for IsvSvn {
 #[derive(Default, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct CpuSvn(sgx_cpu_svn_t);
 
+impl Display for ConfigSvn {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        mc_sgx_util::fmt_hex(&self.0.to_be_bytes(), f)
+    }
+}
+
 impl_newtype_for_bytestruct! {
     CpuSvn, sgx_cpu_svn_t, SGX_CPUSVN_SIZE, svn;
 }


### PR DESCRIPTION
### Motivation

Implements `Display` for the remaining structs in `mc-sgx-core-types`. Implementing `Display` allows us to create better `Display` impls for Verifiers in the `attestation` repo. 


