### PR TITLE
Add verification of `Quote3`

### DIFF
--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -35,4 +35,5 @@ x509-cert = { version = "0.2.0", default-features = false, optional = true }
 [dev-dependencies]
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.6.0" }
 textwrap = "0.16.0"
+x509-cert = { version = "0.2.0", default-features = false, features = ["pem"] }
 yare = "1.0.1"

--- a/dcap/types/src/error.rs
+++ b/dcap/types/src/error.rs
@@ -22,6 +22,8 @@ pub enum Quote3Error {
     Ecdsa,
     /// Invalid certification data type: {0}, should be 1 - 7
     CertificationDataType(u16),
+    /// Error verifying the signature
+    SignatureVerification,
 }
 
 impl Quote3Error {


### PR DESCRIPTION
Adds logic to verify the contents of a `Quote3` quote with a provided
key. The `CertificationData` of the quote is not verified as it's from
this data that the quote signing key is retrieved.

