### PR TITLE
Update `Attributes::set_*` methods to use explicit types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `mc-sgx-core-types::Attributes::set_flags()` and
+  `mc-sgx-core-types::Attributes::set_extended_features_mask()` have been
+  updated to take dedicated types `mc-sgx-core-types::AttributesFlags` and
+  `mc-sgx-core-types::ExtendedFeaturesMask` respectively.
+
 ## [0.6.1] - 2023-05-23
 
 ### Added

--- a/core/types/src/key_request.rs
+++ b/core/types/src/key_request.rs
@@ -198,6 +198,7 @@ mod test {
     extern crate std;
 
     use super::*;
+    use crate::{AttributeFlags, ExtendedFeatureRequestMask};
     use mc_sgx_core_sys_types::SGX_CPUSVN_SIZE;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -227,8 +228,8 @@ mod test {
             .cpu_svn(&CpuSvn::from([3; CpuSvn::SIZE]))
             .attributes(
                 Attributes::default()
-                    .set_flags(4)
-                    .set_extended_features_mask(6),
+                    .set_flags(AttributeFlags::MODE_64BIT)
+                    .set_extended_features_mask(ExtendedFeatureRequestMask::AVX),
             )
             .miscellaneous_select(&7.into())
             .config_svn(&ConfigSvn::from(8))

--- a/core/types/src/lib.rs
+++ b/core/types/src/lib.rs
@@ -21,7 +21,10 @@ mod target_info;
 
 pub use crate::{
     attestation_key::{AttestationKeyId, ExtendedAttestationKeyId},
-    attributes::{Attributes, MiscellaneousAttribute, MiscellaneousSelect},
+    attributes::{
+        AttributeFlags, Attributes, ExtendedFeatureRequestMask, MiscellaneousAttribute,
+        MiscellaneousSelect,
+    },
     config_id::ConfigId,
     error::{Error, FfiError},
     key_request::{KeyName, KeyPolicy, KeyRequest, KeyRequestBuilder},

--- a/core/types/src/report.rs
+++ b/core/types/src/report.rs
@@ -272,7 +272,9 @@ mod test {
     extern crate std;
 
     use super::*;
-    use crate::{key_request::KeyId, MrEnclave, MrSigner};
+    use crate::{
+        key_request::KeyId, AttributeFlags, ExtendedFeatureRequestMask, MrEnclave, MrSigner,
+    };
     use core::{mem, slice};
     use mc_sgx_core_sys_types::{SGX_KEYID_SIZE, SGX_MAC_SIZE};
     use std::format;
@@ -285,8 +287,8 @@ mod test {
             reserved1: [3u8; SGX_REPORT_BODY_RESERVED1_BYTES],
             isv_ext_prod_id: [4u8; SGX_ISVEXT_PROD_ID_SIZE],
             attributes: Attributes::default()
-                .set_flags(5)
-                .set_extended_features_mask(6)
+                .set_flags(AttributeFlags::INITTED | AttributeFlags::MODE_64BIT)
+                .set_extended_features_mask(ExtendedFeatureRequestMask::AVX)
                 .into(),
             mr_enclave: MrEnclave::from([7u8; MrEnclave::SIZE]).into(),
             reserved2: [8u8; SGX_REPORT_BODY_RESERVED2_BYTES],
@@ -311,8 +313,14 @@ mod test {
             reserved1: [32u8; SGX_REPORT_BODY_RESERVED1_BYTES],
             isv_ext_prod_id: [42u8; SGX_ISVEXT_PROD_ID_SIZE],
             attributes: Attributes::default()
-                .set_flags(52)
-                .set_extended_features_mask(62)
+                .set_flags(
+                    AttributeFlags::MODE_64BIT
+                        | AttributeFlags::PROVISION_KEY
+                        | AttributeFlags::EINIT_TOKEN_KEY,
+                )
+                .set_extended_features_mask(
+                    ExtendedFeatureRequestMask::AVX | ExtendedFeatureRequestMask::MPX,
+                )
                 .into(),
             mr_enclave: MrEnclave::from([72u8; MrEnclave::SIZE]).into(),
             reserved2: [82u8; SGX_REPORT_BODY_RESERVED2_BYTES],
@@ -379,8 +387,8 @@ mod test {
         assert_eq!(
             body.attributes(),
             Attributes::default()
-                .set_flags(5)
-                .set_extended_features_mask(6)
+                .set_flags(AttributeFlags::INITTED | AttributeFlags::MODE_64BIT)
+                .set_extended_features_mask(ExtendedFeatureRequestMask::AVX)
         );
         assert_eq!(body.mr_enclave(), MrEnclave::from([7u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved2, [8u8; SGX_REPORT_BODY_RESERVED2_BYTES]);
@@ -426,8 +434,14 @@ mod test {
         assert_eq!(
             body.attributes(),
             Attributes::default()
-                .set_flags(52)
-                .set_extended_features_mask(62)
+                .set_flags(
+                    AttributeFlags::MODE_64BIT
+                        | AttributeFlags::PROVISION_KEY
+                        | AttributeFlags::EINIT_TOKEN_KEY
+                )
+                .set_extended_features_mask(
+                    ExtendedFeatureRequestMask::AVX | ExtendedFeatureRequestMask::MPX
+                )
         );
         assert_eq!(body.mr_enclave(), MrEnclave::from([72u8; SGX_HASH_SIZE]));
         assert_eq!(body.0.reserved2, [82u8; SGX_REPORT_BODY_RESERVED2_BYTES]);

--- a/core/types/src/target_info.rs
+++ b/core/types/src/target_info.rs
@@ -45,6 +45,7 @@ impl_newtype! {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{AttributeFlags, ExtendedFeatureRequestMask};
     use mc_sgx_core_sys_types::{
         SGX_CONFIGID_SIZE, SGX_HASH_SIZE, SGX_TARGET_INFO_RESERVED1_BYTES,
         SGX_TARGET_INFO_RESERVED2_BYTES, SGX_TARGET_INFO_RESERVED3_BYTES,
@@ -65,8 +66,8 @@ mod test {
         let info = sgx_target_info_t {
             mr_enclave: MrEnclave::from([1u8; MrEnclave::SIZE]).into(),
             attributes: Attributes::default()
-                .set_flags(2)
-                .set_extended_features_mask(3)
+                .set_flags(AttributeFlags::DEBUG)
+                .set_extended_features_mask(ExtendedFeatureRequestMask::LEGACY)
                 .into(),
             reserved1: [4u8; SGX_TARGET_INFO_RESERVED1_BYTES],
             config_svn: 5,
@@ -82,8 +83,8 @@ mod test {
         assert_eq!(
             info.attributes(),
             Attributes::default()
-                .set_flags(2)
-                .set_extended_features_mask(3)
+                .set_flags(AttributeFlags::DEBUG)
+                .set_extended_features_mask(ExtendedFeatureRequestMask::LEGACY)
         );
         assert_eq!(info.config_svn(), ConfigSvn::from(5));
         assert_eq!(info.miscellaneous_select(), MiscellaneousSelect::from(6));

--- a/tservice/src/seal.rs
+++ b/tservice/src/seal.rs
@@ -3,7 +3,7 @@
 
 use alloc::{format, string::String, vec, vec::Vec};
 use core::{mem, ptr, result::Result as CoreResult};
-use mc_sgx_core_types::{Attributes, KeyPolicy, MiscellaneousSelect};
+use mc_sgx_core_types::{AttributeFlags, Attributes, KeyPolicy, MiscellaneousSelect};
 use mc_sgx_trts::EnclaveMemory;
 use mc_sgx_tservice_sys_types::sgx_sealed_data_t;
 pub use mc_sgx_tservice_types::Sealed;
@@ -13,10 +13,8 @@ use mc_sgx_util::ResultInto;
 // `sgx_seal_data`. See
 // https://download.01.org/intel-sgx/sgx-linux/2.17.1/docs/Intel_SGX_Developer_Reference_Linux_2.17.1_Open_Source.pdf
 // Some fo these values can also be seen in the internal SGX SDK headers:
-// - TSEAL_DEFAULT_FLAGSMASK => DEFAULT_ATTRIBUTES_FLAGS_FOR_SEAL
 // - TSEAL_DEFAULT_MISCMASK => DEFAULT_MISCELLANEOUS_MASK_FOR_SEAL
 const DEFAULT_MISCELLANEOUS_MASK_FOR_SEAL: u32 = 0xF0000000;
-const DEFAULT_ATTRIBUTES_FLAGS_FOR_SEAL: u64 = 0xFF0000000000000B;
 const DEFAULT_KEY_POLICY_FOR_SEAL: KeyPolicy = KeyPolicy::MRSIGNER;
 
 pub type Result<T> = CoreResult<T, Error>;
@@ -111,7 +109,7 @@ impl<T: AsRef<[u8]> + Default> SealedBuilder<T> {
 
         // Currently see no reason to expose attributes as an option.  Exposing
         // the attributes will require some error handling and normalization
-        let attributes = Attributes::default().set_flags(DEFAULT_ATTRIBUTES_FLAGS_FOR_SEAL);
+        let attributes = Attributes::default().set_flags(AttributeFlags::SEALED_DATA);
 
         // Since `misc_mask` is reserved for future extension omitting from
         // the builder


### PR DESCRIPTION
Previously `Attributes:set_flags()` and
`Attributes::set_extended_features_mask()` used `u64` for the bits. This
provided no type safety or assurances that the correct bits were being
set. Now both methods use a dedicated bitflag type `AttributeFlags` and
`ExtendedFeatureRequestMask`.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

