### PR TITLE
Add trait to get verification collateral

### DIFF
--- a/dcap/quoteverify/Cargo.toml
+++ b/dcap/quoteverify/Cargo.toml
@@ -17,6 +17,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-dcap-quoteverify-sys = { path = "sys", version = "=0.6.1" }
 mc-sgx-dcap-quoteverify-sys-types = { path = "sys/types", version = "=0.6.1" }
 mc-sgx-dcap-quoteverify-types = { path = "types", version = "=0.6.1" }
+mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.6.1" }
 mc-sgx-dcap-types = { path = "../types", version = "=0.6.1" }
 mc-sgx-util = { path = "../../util", version = "=0.6.1" }
 once_cell = "1.17.0"

--- a/dcap/quoteverify/src/collateral.rs
+++ b/dcap/quoteverify/src/collateral.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2023 The MobileCoin Foundation
+
+//! Provides functionality to get collateral for a [`Quote3`].
+
+use crate::{Error, LoadPolicyInitializer, PathInitializer};
+use mc_sgx_dcap_sys_types::sgx_ql_qve_collateral_t;
+use mc_sgx_dcap_types::Quote3;
+use mc_sgx_util::ResultInto;
+use std::mem;
+
+/// The minimum size from `tee_qv_get_collateral` for the pointer to contain a
+/// valid collateral.
+const MIN_SGX_COLLATERAL_SIZE: u32 = mem::size_of::<sgx_ql_qve_collateral_t>() as u32;
+
+/// A pointer to [`sgx_ql_qve_collateral_t`] that will free on drop
+#[derive(Debug, PartialEq)]
+pub struct CollateralPointer {
+    collateral: *mut sgx_ql_qve_collateral_t,
+}
+
+impl Drop for CollateralPointer {
+    fn drop(&mut self) {
+        unsafe {
+            mc_sgx_dcap_quoteverify_sys::tee_qv_free_collateral(self.collateral as *mut u8);
+        }
+    }
+}
+
+/// Collateral is additional data that is used in verification.
+///
+/// The data can be retrieved from `tee_qv_get_collateral()` or from the
+/// following individual endpoints:
+/// - <https://api.portal.trustedservices.intel.com/documentation#pcs-revocation-v4>
+/// - <https://api.portal.trustedservices.intel.com/documentation#pcs-tcb-info-v4>
+/// - <https://api.portal.trustedservices.intel.com/documentation#pcs-enclave-identity-v4>
+/// - <https://certificates.trustedservices.intel.com/IntelSGXRootCA.der>
+pub trait Collateral {
+    /// Get the collateral for `self`.
+    fn collateral(&self) -> Result<CollateralPointer, Error>;
+}
+
+impl<T: AsRef<[u8]>> Collateral for Quote3<T> {
+    fn collateral(&self) -> Result<CollateralPointer, Error> {
+        PathInitializer::ensure_initialized()?;
+        LoadPolicyInitializer::ensure_initialized()?;
+
+        let quote_slice = self.as_ref();
+        let mut sgx_collateral = core::ptr::null_mut();
+        let mut collateral_size = 0;
+
+        unsafe {
+            mc_sgx_dcap_quoteverify_sys::tee_qv_get_collateral(
+                quote_slice.as_ptr(),
+                quote_slice.len() as u32,
+                &mut sgx_collateral,
+                &mut collateral_size,
+            )
+        }
+        .into_result()?;
+
+        // The `collateral_size` is the size of the base structure plus the size
+        // of all the bytes that the members point to. Thus it should always be
+        // greater than `MIN_SGX_COLLATERAL_SIZE`.
+        if collateral_size < MIN_SGX_COLLATERAL_SIZE {
+            return Err(Error::CollateralSizeTooSmall(
+                MIN_SGX_COLLATERAL_SIZE,
+                collateral_size,
+            ));
+        }
+
+        Ok(CollateralPointer {
+            collateral: sgx_collateral as *mut _,
+        })
+    }
+}

--- a/dcap/quoteverify/src/collateral.rs
+++ b/dcap/quoteverify/src/collateral.rs
@@ -58,6 +58,10 @@ impl<T: AsRef<[u8]>> Collateral for Quote3<T> {
         }
         .into_result()?;
 
+        let collateral_pointer = CollateralPointer {
+            collateral: sgx_collateral as *mut _,
+        };
+
         // The `collateral_size` is the size of the base structure plus the size
         // of all the bytes that the members point to. Thus it should always be
         // greater than `MIN_SGX_COLLATERAL_SIZE`.
@@ -68,8 +72,6 @@ impl<T: AsRef<[u8]>> Collateral for Quote3<T> {
             ));
         }
 
-        Ok(CollateralPointer {
-            collateral: sgx_collateral as *mut _,
-        })
+        Ok(collateral_pointer)
     }
 }

--- a/dcap/quoteverify/src/lib.rs
+++ b/dcap/quoteverify/src/lib.rs
@@ -3,9 +3,11 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs, missing_debug_implementations)]
 
+mod collateral;
 mod quote_enclave;
 mod verify;
 
+pub use collateral::{Collateral, CollateralPointer};
 use mc_sgx_dcap_types::QlError;
 pub use quote_enclave::{LoadPolicyInitializer, PathInitializer};
 pub use verify::supplemental_data_size;
@@ -26,6 +28,8 @@ pub enum Error {
     PathLengthTooLong(String),
     /// The quote verification enclave load policy has already been initialized
     LoadPolicyInitialized,
+    /// Collateral data size is too small: should be at least {0}, got {1}
+    CollateralSizeTooSmall(u32, u32),
 }
 
 impl From<QlError> for Error {

--- a/dcap/quoteverify/sys/build.rs
+++ b/dcap/quoteverify/sys/build.rs
@@ -9,6 +9,8 @@ const DCAP_QL_FUNCTIONS: &[&str] = &[
     "sgx_qv_set_enclave_load_policy",
     "sgx_qv_set_path",
     "sgx_qv_verify_quote",
+    "tee_qv_get_collateral",
+    "tee_qv_free_collateral",
 ];
 
 fn main() {

--- a/dcap/types/src/quote3.rs
+++ b/dcap/types/src/quote3.rs
@@ -254,6 +254,12 @@ impl TryFrom<Vec<u8>> for Quote3<Vec<u8>> {
     }
 }
 
+impl<T: AsRef<[u8]>> AsRef<[u8]> for Quote3<T> {
+    fn as_ref(&self) -> &[u8] {
+        self.raw_bytes.as_ref()
+    }
+}
+
 /// Signature Data
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignatureData<'a> {
@@ -670,6 +676,7 @@ mod test {
         );
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn quote_fails_to_decode_attestation_key() {
         let mut hw_quote = include_bytes!("../data/tests/hw_quote.dat").to_vec();
@@ -1016,6 +1023,7 @@ mod test {
         assert_eq!(quote.verify(&key), Ok(()));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn quote_verification_fails_for_bad_qe_report() {
         let mut hw_quote = include_bytes!("../data/tests/hw_quote.dat").to_vec();
@@ -1026,6 +1034,7 @@ mod test {
         assert_eq!(quote.verify(&key), Err(Quote3Error::SignatureVerification));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn quote_verification_fails_for_bad_attestation_key() {
         let mut hw_quote = include_bytes!("../data/tests/hw_quote.dat").to_vec();
@@ -1049,6 +1058,7 @@ mod test {
         assert_eq!(quote.verify(&key), Err(Quote3Error::SignatureVerification));
     }
 
+    #[cfg(feature = "alloc")]
     #[test]
     fn quote_verification_fails_for_isv_report() {
         let mut hw_quote = include_bytes!("../data/tests/hw_quote.dat").to_vec();


### PR DESCRIPTION
Add a trait `mc-sgx-dcap-quoteverify::Collateral` and an implementation
that can get collateral for a `mc-sgx-dcap-types::Quote3`.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

