### PR TITLE
Fix `x509-cert` crate version in `mc-sgx-dcap-types`

### DIFF
--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -35,5 +35,5 @@ x509-cert = { version = "0.2.3", default-features = false, features = ["pem"], o
 assert_matches = "1.5.0"
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.6.1" }
 textwrap = "0.16.0"
-x509-cert = { version = "0.2.0", default-features = false, features = ["pem"] }
+x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
 yare = "1.0.1"

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.6", default-features = false }
 static_assertions = "1.1.0"
 subtle = { version = "2.4.1", default-features = false }
-x509-cert = { version = "0.2.0", default-features = false, features = ["pem"], optional = true }
+x509-cert = { version = "0.2.3", default-features = false, features = ["pem"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
Previously `mc-sgx-dcap-types` specified `x509-cert` at version `0.2.0`.
This version is too low since `mc-sgx-dcap-types` uses the function
[`load_pem_chain`](https://docs.rs/x509-cert/latest/x509_cert/certificate/struct.CertificateInner.html#method.load_pem_chain)
which was added in `0.2.3`.

