### PR TITLE
Add De/Serialize for `Qoute3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
  "nom",
  "p256",
  "serde",
+ "serde_cbor",
  "sha2",
  "static_assertions",
  "subtle",

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -34,6 +34,7 @@ x509-cert = { version = "0.2.3", default-features = false, features = ["pem"], o
 [dev-dependencies]
 assert_matches = "1.5.0"
 mc-sgx-core-sys-types = { path = "../../core/sys/types", version = "=0.7.1" }
+serde_cbor = "0.11.2"
 textwrap = "0.16.0"
 x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
 yare = "1.0.1"


### PR DESCRIPTION
The `Quote3` type is used to go to/from an enclave from the
untrusted application, so it needs to support serialization.


