### PR TITLE
Add Deserialize for `Quote3<Vec<u8>>`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,3 +50,5 @@ RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -
 
 # Install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN echo "[ -f /opt/intel/sgxsdk/environment ] && . /opt/intel/sgxsdk/environment" >> ~/.zshenv


### PR DESCRIPTION
Previously `Deserialize` was only implemented for `Quote3<&[u8]>`. Now
it's also implemented for the `Quote3<Vec<u8>>` type.

### Motivation

The main [MobileCoin](https://github.com/mobilecoinfoundation/mobilecoin) repo passes quotes into and out of the enclave. This requires the owned `Quote3<Vec<u8>>` version to be serializable as well as the borrowed `Quote<&[u8]>` version.
