### PR TITLE
Loosen the version of serde in `Cargo.toml` files

### DIFF
--- a/capable/types/Cargo.toml
+++ b/capable/types/Cargo.toml
@@ -19,7 +19,7 @@ displaydoc = { version = "0.2.3", default-features = false }
 mc-sgx-capable-sys-types = { path = "../sys/types", version = "=0.7.2" }
 mc-sgx-core-types = { path = "../../core/types", version = "=0.7.2" }
 mc-sgx-util = { path = "../../util", version = "=0.7.2" }
-serde = { version = "1.0.173", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 yare = "1.0.1"

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -23,7 +23,7 @@ mc-sgx-core-sys-types = { path = "../sys/types", version = "=0.7.2" }
 mc-sgx-util = { path = "../../util", version = "=0.7.2" }
 nom = { version = "7.1.2", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
-serde = { version = "1.0.173", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 # `getrandom` is pulled in by `rand_core` we only need to access it directly when registering a custom spng,
 # `register_custom_getrandom`, which only happens for target_os = none

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -25,7 +25,7 @@ mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.7.2" }
 mc-sgx-util = { path = "../../util", version = "=0.7.2" }
 nom = { version = "7.1.2", default-features = false }
 p256 = { version = "0.13.0", default-features = false, features = ["ecdsa-core", "ecdsa"] }
-serde = { version = "1.0.173", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.6", default-features = false }
 static_assertions = "1.1.0"
 subtle = { version = "2.4.1", default-features = false }

--- a/tservice/Cargo.toml
+++ b/tservice/Cargo.toml
@@ -25,7 +25,7 @@ mc-sgx-tservice-sys = { path = "sys", version = "=0.7.2" }
 mc-sgx-tservice-sys-types = { path = "sys/types", version = "=0.7.2" }
 mc-sgx-tservice-types = { path = "types", version = "=0.7.2", features = [ "alloc" ] }
 mc-sgx-util = { path = "../util", version = "=0.7.2" }
-serde = { version = "1.0.173", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 mc-sgx-tservice-types = { path = "types", version = "=0.7.2", features = [ "test-utils" ] }


### PR DESCRIPTION
Previously the serde version was requiring a minimum patch version. This
was more constraining for consumers of the crates than necessary. Now
the `Cargo.toml` files only specify the Major.Minor version numbers for
serde.

### Motivation

This was requiring the main [MobileCoin repo](https://github.com/mobilecoinfoundation/mobilecoin) to be n'sync with the newest version of serde these crates new about.

### Future Work

When time permits it would be good to have a CI run that does a build with the `-Z minimum-versions` flag to ensure the minimum versions are specified correctly

