### PR TITLE
Fix `tcb` feature in `mc-sgx-dcap-types` missing dependency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,30 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo +${{ matrix.rust }} build --release --locked
 
+  build-all-features:
+    runs-on: ubuntu-22.04
+    needs:
+      - "lint"
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly-2022-12-13
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mobilecoinfoundation/actions/sgxsdk@main
+        with:
+          version: 2.19.100.3
+      - uses: mobilecoinfoundation/actions/dcap-libs@main
+        with:
+          version: 1.16.100.2-jammy1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - uses: r7kamura/rust-problem-matchers@v1
+      - run: cargo +${{ matrix.rust }} build --release --locked --all-features
+
   test:
     runs-on: ubuntu-22.04
     needs:

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.62.1"
 [features]
 default = []
 alloc = ["dep:x509-cert"]
-tcb = ["alloc", "dep:x509-cert", "dep:const-oid", "dep:hex"]
+tcb = ["alloc", "dep:x509-cert", "dep:const-oid", "dep:hex", "serde/alloc"]
 
 [dependencies]
 const-oid = { version = "0.9.2", default-features = false, optional = true }


### PR DESCRIPTION
Previously the `tcb` feature in `mc-sgx-dcap-types` was not specifying
the need for `serde/alloc`. `serde/alloc` is now a dependency of the
`tcb` feature.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

