### PR TITLE
Fix clippy beta warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
       - uses: r7kamura/rust-problem-matchers@v1
-      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings `${{ matrix.rust == 'beta' }} && echo "-Aclippy::incorrect_clone_impl_on_copy_type"`
 
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
A new clippy check is on by default in the beta channel,
`incorrect_clone_impl_on_copy_type`. The generated code from bindgen
does not conform to this. Suppressed this warning from happening in the
module that imports the generated bindings.

