### PR TITLE
Fix `alloc` feature in `mc-sgx-dcap-types` missing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Fixed `alloc` feature in `mc-sgx-dcap-types` missing dependency on `serde/alloc`
+
 ## [0.7.4] - 2023-08-08
 
 ### Fixed

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.62.1"
 
 [features]
 default = []
-alloc = ["dep:x509-cert"]
+alloc = ["dep:x509-cert", "serde/alloc"]
 tcb = ["alloc", "dep:x509-cert", "dep:const-oid", "dep:hex", "serde/alloc"]
 
 [dependencies]


### PR DESCRIPTION
Previously the `alloc` feature in `mc-sgx-dcap-types` was not specifying
the need for `serde/alloc`. `serde/alloc` is now a dependency of the
`alloc` feature.
