### PR TITLE
Fix logic to update README of `mc-sgx-core-build`

### DIFF
--- a/core/build/Cargo.toml
+++ b/core/build/Cargo.toml
@@ -25,4 +25,5 @@ pre-release-replacements = [
     {file="../../CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
     {file="../../CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly=1},
     {file="../../CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/mobilecoinfoundation/sgx/compare/{{tag_name}}...HEAD", exactly=1},
+    {file="README.md", search="mc-sgx-[a-z-]+/[0-9.]+", replace="{{crate_name}}/{{version}}"},
 ]


### PR DESCRIPTION
When using `cargo release` one crate in a repository has settings on
how to update the CHANGELOG. Since this crate has the Cargo.toml entry
`[package.metadata.release]` it will not look at the entry in the root
`Cargo.toml`. The common settings of updating the README must be
repeated in this crate's `[package.metadata.release]`.

