### PR TITLE
Add `ConstantTimeEq` impl for wrapped byte structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Deserialize` and `Serialize` traits to:
   - `mc-sgx-core-types::QuoteNonce`
+- Added `ConstantTimeEq` trait to:
+  - `mc-sgx-core-types::QuoteNonce`
+  - `mc-sgx-core-types::Basename`
+  - `mc-sgx-core-types::PlatformInfo`
+  - `mc-sgx-core-types::ReportData`
+  - `mc-sgx-core-types::KeyId`
+  - `mc-sgx-core-types::MrEnclave`
+  - `mc-sgx-core-types::MrSigner`
+  - `mc-sgx-core-types::CpuSvn`
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_cbor",
+ "subtle",
  "textwrap",
  "yare",
 ]

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -24,6 +24,7 @@ mc-sgx-util = { path = "../../util", version = "=0.7.4" }
 nom = { version = "7.1.2", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+subtle = { version = "2", default-features = false }
 
 # `getrandom` is pulled in by `rand_core` we only need to access it directly when registering a custom spng,
 # `register_custom_getrandom`, which only happens for target_os = none

--- a/core/types/src/macros.rs
+++ b/core/types/src/macros.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "alloc")]
 pub(crate) use alloc::vec::Vec;
 
+pub(crate) use subtle::ConstantTimeEq;
+
 /// Boilerplate macro to fill in any trait implementations required by
 /// an SgxWrapperType that don't depend on the contents of the inner
 /// type.
@@ -94,6 +96,12 @@ macro_rules! impl_newtype_for_bytestruct {
         impl AsMut<[u8]> for $wrapper {
             fn as_mut(&mut self) -> &mut [u8] {
                 &mut (self.0).$fieldname[..]
+            }
+        }
+
+        impl $crate::macros::ConstantTimeEq for $wrapper {
+            fn ct_eq(&self, other: &Self) -> subtle::Choice {
+                (self.0).$fieldname[..].ct_eq(&(other.0).$fieldname[..])
             }
         }
 

--- a/dcap/types/Cargo.toml
+++ b/dcap/types/Cargo.toml
@@ -28,7 +28,7 @@ p256 = { version = "0.13.0", default-features = false, features = ["ecdsa-core",
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.10.6", default-features = false }
 static_assertions = "1.1.0"
-subtle = { version = "2.4.1", default-features = false }
+subtle = { version = "2", default-features = false }
 x509-cert = { version = "0.2.3", default-features = false, features = ["pem"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Types that wrap a byte struct,
`pub struct foo { pub bytes: [u8; some_size] }`,
now implement the `ConstantTimeEq` trait.

