### PR TITLE
Update for new lints arriving in 1.72 stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
       - uses: r7kamura/rust-problem-matchers@v1
-      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings `${{ matrix.rust == 'beta' }} && echo "-Aclippy::incorrect_clone_impl_on_copy_type"`
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings -Aclippy::incorrect_clone_impl_on_copy_type
 
   build:
     runs-on: ubuntu-22.04

--- a/dcap/types/src/certification_data.rs
+++ b/dcap/types/src/certification_data.rs
@@ -432,7 +432,7 @@ mod test {
         let mut cert_data = [0u8; MIN_CERT_DATA_SIZE];
         cert_data[0] = 5;
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -453,7 +453,7 @@ mod test {
         cert_data.extend(cert);
 
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -486,7 +486,7 @@ mod test {
         cert_chain.splice(2..2, size_bytes);
 
         let certification_data = CertificationData::try_from(cert_chain.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -512,7 +512,7 @@ mod test {
         cert_data.extend(pem);
 
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -543,7 +543,7 @@ mod test {
         cert_data.extend(pem);
 
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -574,7 +574,7 @@ mod test {
         cert_data.extend(pem);
 
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -607,7 +607,7 @@ mod test {
         cert_data.extend(key);
 
         let certification_data = CertificationData::try_from(cert_data.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();
@@ -646,7 +646,7 @@ mod test {
         cert_chain.splice(2..2, size_bytes);
 
         let certification_data = CertificationData::try_from(cert_chain.as_slice()).unwrap();
-        let CertificationData::PckCertificateChain(cert_chain) = certification_data  else {
+        let CertificationData::PckCertificateChain(cert_chain) = certification_data else {
             panic!("expected a PckCertChain");
         };
         let cert_iter = cert_chain.into_iter();


### PR DESCRIPTION
Previously there were extra spaces before some braces that cargo fmt
1.72 now removes. We also only suppressed the
`incorrect_clone_impl_on_copy_type` clippy warning on beta. This is now
suppressed for both stable and beta CI runs. This is *not* suppressed at
globally or at the usage location as it would violate our 1.62.1 MSRV.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

