### PR TITLE
Remove bumping `codecov-action` to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,7 @@ jobs:
         # We can't just set to 0 or "" as the SGX code looks for it being set, not what the value is :(
         # The FFI bindings crates always report 100% because they have no code
         run: unset SGX_AESM_ADDR && cargo llvm-cov --locked --features sim --ignore-filename-regex '\/sys/src/lib\.rs' --workspace --lcov --output-path lcov.info
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         with:
           files: lcov.info
 


### PR DESCRIPTION
Dependabot had bumped the codecov action to v4 and it passed CI, but now
it doesn't. I'm guessing there was a mistake where they removed v4. At
the time of this PR there are v4-beta tags.

