### PR TITLE
Fix CI for a yanked crate version

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+# RUSTSEC-2021-0127 - is for serde-cbor which is unmaintained
+# at this time there still isn't a good alternative.
+# `serde-cbor` is what the main MobileCoin repo uses into and out of the 
+# enclaves, we only use it for testing in this repo to ensure it works as 
+# expected.
+ignore = ["RUSTSEC-2021-0127"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo fmt --all -- --check
       - uses: xt0rted/markdownlint-problem-matcher@v2
-      - uses: DavidAnson/markdownlint-cli2-action@v13
+      - uses: DavidAnson/markdownlint-cli2-action@v14
         with:
           globs: "**/*.md"
 
@@ -70,19 +70,12 @@ jobs:
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
           version: 1.18.100.1-jammy1
-      - id: suppression
-        run: |
-          if [ "${{ matrix.rust }}" == "stable" ]; then
-            echo "suppression=-Aclippy::incorrect_clone_impl_on_copy_type" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.rust }}" == "beta" ]; then
-            echo "suppression=-Aclippy::non_canonical_clone_impl" >> "$GITHUB_OUTPUT"
-          fi
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
       - uses: r7kamura/rust-problem-matchers@v1
-      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings ${{ steps.suppression.outputs.suppression }}
+      - run: cargo +${{ matrix.rust }} clippy --all --all-features -- -D warnings -Aclippy::non_canonical_clone_impl
 
   build:
     runs-on: ubuntu-22.04

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,7 +2,7 @@
   // Disable some built-in rules
   "config": {
     "line-length": false,
-    "no-duplicate-header": {
+    "no-duplicate-heading": {
         // Allow multiple "Added" sections in the changelog
         "siblings_only": true
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -391,15 +380,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1321,13 +1301,9 @@ checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-linebreak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
-dependencies = [
- "hashbrown 0.12.3",
- "regex",
-]
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"


### PR DESCRIPTION
The locked version of ahash was yanked. This updates ahash to a newer
version.

