### PR TITLE
Update SGX SDK to 2.22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,14 +12,14 @@ RUN  apt-get update \
   && rm -r /var/lib/apt/lists
 
 # Install SGX_SDK
-ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.21/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.21.100.1.bin
+ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.22/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.22.100.3.bin
 RUN  curl -o sgx.bin "${SGX_URL}" \
   && chmod +x ./sgx.bin \
   && ./sgx.bin --prefix=/opt/intel \
   && rm ./sgx.bin
 
 # Install DCAP libraries
-ARG DCAP_VERSION=1.18.100.1-jammy1
+ARG DCAP_VERSION=1.19.100.3-jammy1
 RUN mkdir -p /etc/apt/keyrings \
   && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor | tee /etc/apt/keyrings/intel-sgx.gpg > /dev/null \
   && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" | tee /etc/apt/sources.list.d/intel-sgx.list \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.18.100.1-jammy1
+          version: 1.19.100.3-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -91,10 +91,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.21.100.1
+          version: 2.22.100.3
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.18.100.1-jammy1
+          version: 1.19.100.3-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -115,10 +115,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.21.100.1
+          version: 2.22.100.3
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.18.100.1-jammy1
+          version: 1.19.100.3-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -139,10 +139,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.21.100.1
+          version: 2.22.100.3
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.18.100.1-jammy1
+          version: 1.19.100.3-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -180,10 +180,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.21.100.1
+          version: 2.22.100.3
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.18.100.1-jammy1
+          version: 1.19.100.3-jammy1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- The SGX SDK version is now 2.22.100.3
+
 ### Added
 
 - Added `Ord` and `PartialOrd` traits to:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,6 @@ dependencies = [
  "once_cell",
  "serial_test",
  "tempfile",
- "yare",
 ]
 
 [[package]]

--- a/core/build/headers/sgx_dcap_ql_wrapper.h
+++ b/core/build/headers/sgx_dcap_ql_wrapper.h
@@ -67,6 +67,9 @@ typedef enum
     SGX_QL_IDE_PATH,
 } sgx_ql_path_type_t;
 quote3_error_t sgx_ql_set_path(sgx_ql_path_type_t path_type, const char *p_path);
+
+quote3_error_t sgx_ql_set_trace_callback(sgx_ql_logging_callback_t logger, sgx_ql_log_level_t loglevel);
+
 #endif
 
 #if defined(__cplusplus)

--- a/core/build/headers/sgx_dcap_quoteverify.h
+++ b/core/build/headers/sgx_dcap_quoteverify.h
@@ -60,12 +60,12 @@ extern "C" {
  *  SGX_QL_EPHEMERAL_QVE_MULTI_THREAD - QvE is loaded per thread and be unloaded before function exit.
  *  SGX_QL_PERSISTENT_QVE_MULTI_THREAD - QvE is loaded per thread and only be unloaded before thread exit.
  *
- * NOTE: QvE load policy should be only set once in one process, change the policy means all threads will be impacted.
+ * NOTE: QvE load policy should be only set once in one process, otherwise, this function will return error SGX_QL_UNSUPPORTED_LOADING_POLICY.
  *
  * @param policy Sets the requested enclave loading policy to either SGX_QL_PERSISTENT, SGX_QL_EPHEMERAL or SGX_QL_DEFAULT.
  *
  * @return SGX_QL_SUCCESS Successfully set the enclave loading policy for the quoting library's enclaves.
- * @return SGX_QL_UNSUPPORTED_LOADING_POLICY The selected policy is not support by the quoting library.
+ * @return SGX_QL_UNSUPPORTED_LOADING_POLICY The selected policy is not supported or it has been set once.
  *
  **/
 quote3_error_t sgx_qv_set_enclave_load_policy(sgx_ql_request_policy_t policy);

--- a/core/build/headers/sgx_ecp_types.h
+++ b/core/build/headers/sgx_ecp_types.h
@@ -35,10 +35,9 @@
 #define _SGX_ECP_TYPES_H_
 
 #include <stdint.h>
+#include "sgx_tcrypto.h"
 
 #pragma pack(push, 1)
-
-#include "sgx_tcrypto.h"
 
 #ifndef SGX_FEBITSIZE
 #define SGX_FEBITSIZE                   256

--- a/core/build/headers/sgx_error.h
+++ b/core/build/headers/sgx_error.h
@@ -101,7 +101,7 @@ typedef enum _status_t
     SGX_ERROR_PCL_MAC_MISMATCH          = SGX_MK_ERROR(0x6003),   /* section mac result does not match build time mac */
     SGX_ERROR_PCL_SHA_MISMATCH          = SGX_MK_ERROR(0x6004),   /* Unsealed key MAC does not match MAC of key hardcoded in enclave binary */
     SGX_ERROR_PCL_GUID_MISMATCH         = SGX_MK_ERROR(0x6005),   /* GUID in sealed blob does not match GUID hardcoded in enclave binary */
-    
+
     /* SGX errors are only used in the file API when there is no appropriate EXXX (EINVAL, EIO etc.) error code */
     SGX_ERROR_FILE_BAD_STATUS               = SGX_MK_ERROR(0x7001),	/* The file is in bad status, run sgx_clearerr to try and fix it */
     SGX_ERROR_FILE_NO_KEY_ID                = SGX_MK_ERROR(0x7002),	/* The Key ID field is all zeros, can't re-generate the encryption key */
@@ -120,7 +120,8 @@ typedef enum _status_t
     SGX_ERROR_INVALID_ATT_KEY_CERT_DATA     = SGX_MK_ERROR(0x8004),    /* TThe data returned by the platform library's sgx_get_quote_config() is invalid.*/
     SGX_ERROR_PLATFORM_CERT_UNAVAILABLE     = SGX_MK_ERROR(0x8005),    /* The PCK Cert for the platform is not available.*/
 
-    SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED = SGX_MK_ERROR(0xF001), /* The ioctl for enclave_create unexpectedly failed with EINTR. */ 
+    SGX_ERROR_TLS_X509_INVALID_EXTENSION   = SGX_MK_ERROR(0x9001),    /* error of RA-TLS x509 invalid extension */
+    SGX_INTERNAL_ERROR_ENCLAVE_CREATE_INTERRUPTED = SGX_MK_ERROR(0xF001), /* The ioctl for enclave_create unexpectedly failed with EINTR. */
 
 } sgx_status_t;
 

--- a/core/build/headers/sgx_key.h
+++ b/core/build/headers/sgx_key.h
@@ -51,7 +51,7 @@
 
 /* Key Policy */
 #define SGX_KEYPOLICY_MRENCLAVE        0x0001      /* Derive key using the enclave's ENCLAVE measurement register */
-#define SGX_KEYPOLICY_MRSIGNER         0x0002      /* Derive key using the enclave's SINGER measurement register */
+#define SGX_KEYPOLICY_MRSIGNER         0x0002      /* Derive key using the enclave's SIGNER measurement register */
 #define SGX_KEYPOLICY_NOISVPRODID      0x0004      /* Derive key without the enclave's ISVPRODID */
 #define SGX_KEYPOLICY_CONFIGID         0x0008      /* Derive key with the enclave's CONFIGID */
 #define SGX_KEYPOLICY_ISVFAMILYID      0x0010      /* Derive key with the enclave's ISVFAMILYID */

--- a/core/build/headers/sgx_ql_lib_common.h
+++ b/core/build/headers/sgx_ql_lib_common.h
@@ -106,7 +106,8 @@ typedef enum _quote3_error_t {
     SGX_QL_CRL_UNSUPPORTED_FORMAT = SGX_QL_MK_ERROR(0x0038),
     SGX_QL_QEIDENTITY_CHAIN_ERROR = SGX_QL_MK_ERROR(0x0039),
     SGX_QL_TCBINFO_CHAIN_ERROR = SGX_QL_MK_ERROR(0x003a),
-    SGX_QL_ERROR_QVL_QVE_MISMATCH = SGX_QL_MK_ERROR(0x003b),          ///< QvE returned supplemental data version mismatched between QVL and QvE
+    SGX_QL_ERROR_QVL_QVE_MISMATCH = SGX_QL_MK_ERROR(0x003b),          ///< Supplemental data size and version mismatched between QVL and QvE
+                                                                      ///< Please make sure to use QVL and QvE from same release package
     SGX_QL_TCB_SW_HARDENING_NEEDED = SGX_QL_MK_ERROR(0x003c),         ///< TCB up to date but SW Hardening needed
     SGX_QL_TCB_CONFIGURATION_AND_SW_HARDENING_NEEDED = SGX_QL_MK_ERROR(0x003d),        ///< TCB up to date but Configuration and SW Hardening needed
 
@@ -142,6 +143,8 @@ typedef enum _quote3_error_t {
     SGX_QL_TCB_NOT_SUPPORTED = SGX_QL_MK_ERROR(0x0066),              ///< Current TCB level cannot be found in platform/enclave TCB info
 
     SGX_QL_CONFIG_INVALID_JSON = SGX_QL_MK_ERROR(0x0067),            ///< The QPL's config file is in JSON format but has a format error
+
+    SGX_QL_RESULT_INVALID_SIGNATURE = SGX_QL_MK_ERROR(0x0068),    ///< Invalid signature during quote verification
 
     SGX_QL_ERROR_MAX = SGX_QL_MK_ERROR(0x00FF),                      ///< Indicate max error to allow better translation.
 
@@ -236,7 +239,9 @@ typedef struct _sgx_ql_qve_collateral_t
 typedef enum _sgx_ql_log_level_t
 {
     SGX_QL_LOG_ERROR,
-    SGX_QL_LOG_INFO
+    SGX_QL_LOG_INFO,
+    SGX_QL_LOG_DEBUG,
+    SGX_QL_LOG_TRACE,
 } sgx_ql_log_level_t;
 
 typedef void (*sgx_ql_logging_callback_t)(sgx_ql_log_level_t level, const char* message);

--- a/core/build/headers/sgx_tprotected_fs.h
+++ b/core/build/headers/sgx_tprotected_fs.h
@@ -173,6 +173,25 @@ int64_t SGXAPI sgx_ftell(SGX_FILE* stream);
 int32_t SGXAPI sgx_fseek(SGX_FILE* stream, int64_t offset, int origin);
 
 
+/* sgx_fset_parallel_level
+ *  Purpose: set number of threads can be used in file flush
+ *           To achieve the best performance, please only use when write large files (>10M),
+ *           and with a customized cache size (i.e. use sgx_fopen_ex to open file)
+ *           For the reference, test result on ICX server
+ *              - cache size 10M ~ 100M , use 16 ~ 32 threads
+ *              - cache size > 100M, use more than 32 threads
+ *
+ *  Parameters:
+ *      stream - [IN] the file handle (opened with sgx_fopen or sgx_fopen_auto_key)
+ *      max_threads_number - [IN] number of threads can be used in file flush
+ *                           It must NOT exceed the TCS number in enclave configuration
+ *
+ *  Return value:
+ *     int32_t  - result, 0 - success, 1 - there was an error, thread number is 0
+*/
+int32_t SGXAPI sgx_fset_parallel_level(SGX_FILE* stream, uint32_t max_threads_number);
+
+
 /* sgx_fflush
  *  Purpose: force actual write of all the cached data to the disk (see c++ fflush documentation for more details).
  *

--- a/core/build/headers/sgx_tseal.h
+++ b/core/build/headers/sgx_tseal.h
@@ -56,7 +56,7 @@ typedef struct _aes_gcm_data_t
 typedef struct _sealed_data_t
 {
     sgx_key_request_t  key_request;       /* 00: The key request used to obtain the sealing key */
-    uint32_t           plain_text_offset; /* 64: Offset within aes_data.playload to the start of the optional additional MAC text */
+    uint32_t           plain_text_offset; /* 64: Offset within aes_data.payload to the start of the optional additional MAC text */
     uint8_t            reserved[12];      /* 68: Reserved bits */
     sgx_aes_gcm_data_t aes_data;          /* 80: Data structure holding the AES/GCM related data */
 } sgx_sealed_data_t;
@@ -190,8 +190,8 @@ extern "C" {
         uint32_t *p_decrypted_text_length);
 
     /* sgx_mac_aadata
-    * Purpose: Use AES-GCM algorithm to generate a sealed data structure with integrity protection.  
-    *          Specifically, the input data set is ONLY the plaintext data stream, or 
+    * Purpose: Use AES-GCM algorithm to generate a sealed data structure with integrity protection.
+    *          Specifically, the input data set is ONLY the plaintext data stream, or
     *          additional authenticated data(AAD), no encrypt data.
     *          The sgx_sealed_data_t structure should be allocated prior to the API call and
     *          should include buffer storage for the plaintext data.
@@ -237,7 +237,7 @@ extern "C" {
         sgx_sealed_data_t *p_sealed_data);
 
     /* sgx_unmac_aadata
-    * Purpose: Unseal the sealed data structure passed in and populate the plaintext data stream 
+    * Purpose: Unseal the sealed data structure passed in and populate the plaintext data stream
     *          with the appropriate data from the sealed data structure.
     *
     * Parameters:

--- a/dcap/quoteverify/Cargo.toml
+++ b/dcap/quoteverify/Cargo.toml
@@ -26,4 +26,3 @@ once_cell = "1.17.0"
 mc-sgx-dcap-sys-types = { path = "../sys/types", version = "=0.9.0" }
 serial_test = { version = "2.0.0", default-features = false }
 tempfile = "3.7.1"
-yare = "1.0.1"

--- a/dcap/types/src/error.rs
+++ b/dcap/types/src/error.rs
@@ -208,7 +208,10 @@ pub enum QlError {
     QeIdentityChainError = quote3_error_t::SGX_QL_QEIDENTITY_CHAIN_ERROR.0,
     /// ?
     TcbInfoChainError = quote3_error_t::SGX_QL_TCBINFO_CHAIN_ERROR.0,
-    /// QvE returned supplemental data version mismatched between QVL and QvE
+    /**
+     * QvE returned supplemental data version mismatched between QVL and QvE
+     * Please make sure to use QVL and QvE from same release package
+     */
     QvlQveMismatch = quote3_error_t::SGX_QL_ERROR_QVL_QVE_MISMATCH.0,
     /// TCB up to date but SW Hardening needed
     TcbSwHardeningNeeded = quote3_error_t::SGX_QL_TCB_SW_HARDENING_NEEDED.0,
@@ -285,6 +288,8 @@ pub enum QlError {
     TcbNotSupported = quote3_error_t::SGX_QL_TCB_NOT_SUPPORTED.0,
     /// The QPL's config file is in JSON format but has a format error
     ConfigInvalidJson = quote3_error_t::SGX_QL_CONFIG_INVALID_JSON.0,
+    /// Invalid signature during quote verification
+    InvalidSignature = quote3_error_t::SGX_QL_RESULT_INVALID_SIGNATURE.0,
 
     /// Indicate max error to allow better translation
     Max = quote3_error_t::SGX_QL_ERROR_MAX.0,
@@ -423,6 +428,7 @@ impl TryFrom<quote3_error_t> for QlError {
             quote3_error_t::SGX_QL_ROOT_CA_UNTRUSTED => Ok(QlError::RootCaUntrusted),
             quote3_error_t::SGX_QL_TCB_NOT_SUPPORTED => Ok(QlError::TcbNotSupported),
             quote3_error_t::SGX_QL_CONFIG_INVALID_JSON => Ok(QlError::ConfigInvalidJson),
+            quote3_error_t::SGX_QL_RESULT_INVALID_SIGNATURE => Ok(QlError::InvalidSignature),
             quote3_error_t::SGX_QL_ERROR_MAX => Ok(QlError::Max),
             // Map all unknowns to the unexpected error
             _ => Ok(QlError::Unexpected),
@@ -531,6 +537,7 @@ mod test {
     root_ca_untrusted = { quote3_error_t::SGX_QL_ROOT_CA_UNTRUSTED, QlError::RootCaUntrusted },
     tcb_not_supported = { quote3_error_t::SGX_QL_TCB_NOT_SUPPORTED, QlError::TcbNotSupported },
     config_invalid_json = { quote3_error_t::SGX_QL_CONFIG_INVALID_JSON, QlError::ConfigInvalidJson },
+    invalid_signautre = { quote3_error_t::SGX_QL_RESULT_INVALID_SIGNATURE, QlError::InvalidSignature },
     max = { quote3_error_t::SGX_QL_ERROR_MAX, QlError::Max }
     )]
     fn error_from_ffi(ffi: quote3_error_t, expected: QlError) {


### PR DESCRIPTION
For the header file changes, one can look at the following:
- https://github.com/intel/linux-sgx/compare/sgx_2.21...sgx_2.22
- https://github.com/intel/SGXDataCenterAttestationPrimitives/compare/DCAP_1.18...DCAP_1.19