### PR TITLE
Use `lockfile-only` for cargo dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,7 @@ updates:
   open-pull-requests-limit: 25
   commit-message:
     prefix: "chore(deps)"
+  versioning-strategy: lockfile-only
 
 - package-ecosystem: github-actions
   directory: "/"


### PR DESCRIPTION
Previously the dependabot for cargo was using `auto` which would update
both the manifest, `Cargo.toml` files and the `Cargo.lock` file. Since
this repository is for library crates, we only want to update the lock
file that people develop with. We don't want to update the manifest file
and force consumers to update unnecessarily.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy in particularly notice that cargo only supports `auto, lockfile-only`. Ideally we'd use `increase-if-necessary`. An alternative may be to look into rennovate bot, it appears it may support a better option, https://docs.renovatebot.com/configuration-options/#rangestrategy
