### PR TITLE
Update SGX SDK to 2.23

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,14 +12,14 @@ RUN  apt-get update \
   && rm -r /var/lib/apt/lists
 
 # Install SGX_SDK
-ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.22/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.22.100.3.bin
+ARG SGX_URL=https://download.01.org/intel-sgx/sgx-linux/2.23/distro/ubuntu22.04-server/sgx_linux_x64_sdk_2.23.100.2.bin
 RUN  curl -o sgx.bin "${SGX_URL}" \
   && chmod +x ./sgx.bin \
   && ./sgx.bin --prefix=/opt/intel \
   && rm ./sgx.bin
 
 # Install DCAP libraries
-ARG DCAP_VERSION=1.19.100.3-jammy1
+ARG DCAP_VERSION=1.20.100.2-jammy1
 RUN mkdir -p /etc/apt/keyrings \
   && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor | tee /etc/apt/keyrings/intel-sgx.gpg > /dev/null \
   && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main" | tee /etc/apt/sources.list.d/intel-sgx.list \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
         "eamodio.gitlens",
         "vadimcn.vscode-lldb",
         "rust-lang.rust-analyzer",
+        "ms-azuretools.vscode-docker",
       ]
     }
   }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.19.100.3-jammy1
+          version: 1.20.100.2-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -91,10 +91,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.22.100.3
+          version: 2.23.100.2
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.19.100.3-jammy1
+          version: 1.20.100.2-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -115,10 +115,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.22.100.3
+          version: 2.23.100.2
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.19.100.3-jammy1
+          version: 1.20.100.2-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -139,10 +139,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.22.100.3
+          version: 2.23.100.2
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.19.100.3-jammy1
+          version: 1.20.100.2-jammy1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -180,10 +180,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: mobilecoinfoundation/actions/sgxsdk@main
         with:
-          version: 2.22.100.3
+          version: 2.23.100.2
       - uses: mobilecoinfoundation/actions/dcap-libs@main
         with:
-          version: 1.19.100.3-jammy1
+          version: 1.20.100.2-jammy1
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview

--- a/core/build/headers/sgx_dcap_quoteverify.h
+++ b/core/build/headers/sgx_dcap_quoteverify.h
@@ -120,7 +120,6 @@ quote3_error_t sgx_qv_verify_quote(
     uint8_t *p_supplemental_data);
 
 
-
 /**
  * Call quote provider library to get QvE identity.
  *
@@ -165,6 +164,51 @@ typedef enum
 
 quote3_error_t sgx_qv_set_path(sgx_qv_path_type_t path_type,
                                    const char *p_path);
+
+/**
+ * Get quote verification result token.
+ *
+ * @param p_quote[IN] - Pointer to SGX Quote.
+ * @param quote_size[IN] - Size of the buffer pointed to by p_quote (in bytes).
+ * @param p_quote_collateral[IN] - The parameter is optional. This is a pointer to the Quote Certification Collateral provided by the caller.
+ * @param p_qve_report_info[IN/OUT] - This parameter can be used in 2 ways.
+ *        If p_qve_report_info is NOT NULL, the API will use Intel QvE to perform quote verification, and QvE will generate a report using the target_info in sgx_ql_qe_report_info_t structure.
+ *        if p_qve_report_info is NULL, the API will use QVL library to perform quote verification, note that the results can not be cryptographically authenticated in this mode.
+ * @param p_user_data[IN] - User data.
+ * @param p_verification_result_token_buffer_size[OUT] - Size of the buffer pointed to by verification_result_token (in bytes).
+ * @param p_verification_result_token[OUT] - Pointer to the verification_result_token.
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ *      - SGX_QL_QUOTE_FORMAT_UNSUPPORTED
+ *      - SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED
+ *      - SGX_QL_UNABLE_TO_GENERATE_REPORT
+ *      - SGX_QL_CRL_UNSUPPORTED_FORMAT
+ *      - SGX_QL_ERROR_UNEXPECTED
+ **/
+quote3_error_t  tee_verify_quote_qvt(
+    const uint8_t *p_quote,
+    uint32_t quote_size,
+    const sgx_ql_qve_collateral_t *p_quote_collateral,
+    sgx_ql_qe_report_info_t *p_qve_report_info,
+    const uint8_t *p_user_data,
+    uint32_t *p_verification_result_token_buffer_size,
+    uint8_t **p_verification_result_token);
+
+/**
+ * Free quote verification result token buffer, which returned by `tee_verify_quote_qvt`
+ *
+ * @param p_verification_result_token[IN] - Pointer to verification result token
+ * @param p_verification_result_token_buffer_size[IN] - Pointer to verification result token size
+ *
+ * @return Status code of the operation, one of:
+ *      - SGX_QL_SUCCESS
+ *      - SGX_QL_ERROR_INVALID_PARAMETER
+ **/
+quote3_error_t tee_free_verify_quote_qvt(
+    uint8_t *p_verification_result_token,
+    uint32_t *p_verification_result_token_buffer_size);
 #endif
 
 

--- a/core/build/headers/sgx_qve_header.h
+++ b/core/build/headers/sgx_qve_header.h
@@ -41,30 +41,32 @@
 /** Contains the possible values of the quote verification result. */
 typedef enum _sgx_ql_qv_result_t
 {
-   SGX_QL_QV_RESULT_OK = 0x0000,                                            ///< The Quote verification passed and is at the latest TCB level
-   SGX_QL_QV_RESULT_MIN = SGX_QL_QV_MK_ERROR(0x0001),
-   SGX_QL_QV_RESULT_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0001),             ///< The Quote verification passed and the platform is patched to
-                                                                            ///< the latest TCB level but additional configuration of the SGX
-                                                                            ///< platform may be needed
-   SGX_QL_QV_RESULT_OUT_OF_DATE = SGX_QL_QV_MK_ERROR(0x0002),               ///< The Quote is good but TCB level of the platform is out of date.
-                                                                            ///< The platform needs patching to be at the latest TCB level
-   SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0003), ///< The Quote is good but the TCB level of the platform is out of
-                                                                            ///< date and additional configuration of the SGX Platform at its
-                                                                            ///< current patching level may be needed. The platform needs
-                                                                            ///< patching to be at the latest TCB level
-   SGX_QL_QV_RESULT_INVALID_SIGNATURE = SGX_QL_QV_MK_ERROR(0x0004),         ///< The signature over the application report is invalid
-   SGX_QL_QV_RESULT_REVOKED = SGX_QL_QV_MK_ERROR(0x0005),                   ///< The attestation key or platform has been revoked
-   SGX_QL_QV_RESULT_UNSPECIFIED = SGX_QL_QV_MK_ERROR(0x0006),               ///< The Quote verification failed due to an error in one of the input
-   SGX_QL_QV_RESULT_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0007),       ///< The TCB level of the platform is up to date, but SGX SW Hardening
-                                                                            ///< is needed
-   SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0008),   ///< The TCB level of the platform is up to date, but additional
-                                                                                   ///< configuration of the platform at its current patching level
-                                                                                   ///< may be needed. Moreove, SGX SW Hardening is also needed
+    SGX_QL_QV_RESULT_OK = 0x0000,                                            ///< The Quote verification passed and is at the latest TCB level
+    SGX_QL_QV_RESULT_MIN = SGX_QL_QV_MK_ERROR(0x0001),
+    SGX_QL_QV_RESULT_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0001),             ///< The Quote verification passed and the platform is patched to
+                                                                             ///< the latest TCB level but additional configuration of the SGX
+                                                                             ///< platform may be needed
+    SGX_QL_QV_RESULT_OUT_OF_DATE = SGX_QL_QV_MK_ERROR(0x0002),               ///< The Quote is good but TCB level of the platform is out of date.
+                                                                             ///< The platform needs patching to be at the latest TCB level
+    SGX_QL_QV_RESULT_OUT_OF_DATE_CONFIG_NEEDED = SGX_QL_QV_MK_ERROR(0x0003), ///< The Quote is good but the TCB level of the platform is out of
+                                                                             ///< date and additional configuration of the SGX Platform at its
+                                                                             ///< current patching level may be needed. The platform needs
+                                                                             ///< patching to be at the latest TCB level
+    SGX_QL_QV_RESULT_INVALID_SIGNATURE = SGX_QL_QV_MK_ERROR(0x0004),         ///< The signature over the application report is invalid
+    SGX_QL_QV_RESULT_REVOKED = SGX_QL_QV_MK_ERROR(0x0005),                   ///< The attestation key or platform has been revoked
+    SGX_QL_QV_RESULT_UNSPECIFIED = SGX_QL_QV_MK_ERROR(0x0006),               ///< The Quote verification failed due to an error in one of the input
+    SGX_QL_QV_RESULT_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0007),       ///< The TCB level of the platform is up to date, but SGX SW Hardening
+                                                                             ///< is needed
+    SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED = SGX_QL_QV_MK_ERROR(0x0008),   ///< The TCB level of the platform is up to date, but additional
+                                                                                    ///< configuration of the platform at its current patching level
+                                                                                    ///< may be needed. Moreove, SGX SW Hardening is also needed
+    SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED = SGX_QL_QV_MK_ERROR(0x0009),       ///< For TDX only. All components in the TD’s TCB are latest, including the
+                                                                             ///< TD preserving loaded TDX, but the TD was launched and ran for some time
+                                                                             ///< with out-of-date TDX Module. Relaunching or re-provisioning your TD is advised
 
    SGX_QL_QV_RESULT_MAX = SGX_QL_QV_MK_ERROR(0x00FF),                              ///< Indicate max result to allow better translation
 
 } sgx_ql_qv_result_t;
-
 
 typedef enum _pck_cert_flag_enum_t {
     PCK_FLAG_FALSE = 0,
@@ -126,7 +128,12 @@ typedef struct _sgx_ql_qv_supplemental_t
     pck_cert_flag_enum_t smt_enabled;           ///< Indicate whether a plat form has SMT (simultaneous multithreading) enabled
 
     char sa_list[MAX_SA_LIST_SIZE];             ///< String of comma separated list of Security Advisory IDs
-
+    time_t qe_iden_earliest_issue_date;           ///< Earliest issue date of QEIdentity (UTC)
+    time_t qe_iden_latest_issue_date;             ///< Latest issue date of QEIdentity (UTC)
+    time_t qe_iden_earliest_expiration_date;      ///< Earliest expiration date of QEIdentity (UTC)
+    time_t qe_iden_tcb_level_date_tag;            ///< The SGX TCB of the platform that generated the quote is not vulnerable
+    uint32_t qe_iden_tcb_eval_ref_num;            ///< Lower number of the QEIdentity
+    sgx_ql_qv_result_t qe_iden_status;            /// QEIdentity status
 } sgx_ql_qv_supplemental_t;
 
 #ifdef _MSC_VER

--- a/core/build/headers/tlibc/wchar.h
+++ b/core/build/headers/tlibc/wchar.h
@@ -127,6 +127,9 @@ int         _TLIBC_CDECL_ wmemcmp(const wchar_t *, const wchar_t *, size_t);
 wchar_t *   _TLIBC_CDECL_ wmemcpy(wchar_t *, const wchar_t *, size_t);
 wchar_t *   _TLIBC_CDECL_ wmemmove(wchar_t *, const wchar_t *, size_t);
 wchar_t *   _TLIBC_CDECL_ wmemset(wchar_t *, wchar_t, size_t);
+int         _TLIBC_CDECL_ wcsncasecmp(const wchar_t *, const wchar_t *, size_t);
+size_t      _TLIBC_CDECL_ wcsnrtombs(char *__restrict, const wchar_t **__restrict, size_t, size_t, mbstate_t *__restrict);
+size_t      _TLIBC_CDECL_ mbsnrtowcs(wchar_t *__restrict, const char **__restrict, size_t, size_t, mbstate_t *__restrict);
 
 int         _TLIBC_CDECL_ swprintf(wchar_t *, size_t, const wchar_t *, ...);
 int         _TLIBC_CDECL_ vswprintf(wchar_t *, size_t, const wchar_t *, __va_list);


### PR DESCRIPTION
The DCAP diff can be seen here, https://github.com/intel/SGXDataCenterAttestationPrimitives/compare/DCAP_1.19...DCAP_1.20

The main SDK changes can be seen here, https://github.com/intel/linux-sgx/compare/sgx_2.22...sgx_2.23